### PR TITLE
Enforce 15-minute booking cooldown after cancellations

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,5 +11,8 @@
         "*.local"
       ]
     }
-  ]
+  ],
+  "firestore": {
+    "rules": "firestore.rules"
+  }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,77 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+
+    // --- Helpers ---
+    function isSignedIn() {
+      return request.auth != null;
+    }
+    function isAdmin() {
+      return isSignedIn()
+        && request.auth.token != null
+        && ('admin' in request.auth.token)
+        && request.auth.token.admin == true;
+    }
+    function cooldownOk(uid) {
+      let cancel = get(/databases/$(db)/documents/users/$(uid)).data.lastCancelAt;
+      return cancel == null || request.time.toMillis() - cancel.toMillis() >= 15 * 60 * 1000;
+    }
+
+    // ===== CLASSES =====
+    match /classes/{classId} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
+      allow update: if isSignedIn()
+        && request.resource.data.diff(resource.data).changedKeys().hasOnly(['enrolledCount'])
+        && (
+          request.resource.data.enrolledCount == resource.data.enrolledCount + 1 ||
+          request.resource.data.enrolledCount == resource.data.enrolledCount - 1
+        );
+    }
+
+    // ===== BOOKINGS =====
+    match /bookings/{bookingId} {
+      allow get: if isSignedIn();
+      allow read: if (isSignedIn() && resource.data.userId == request.auth.uid) || isAdmin();
+      allow create: if isSignedIn()
+        && request.resource.data.userId == request.auth.uid
+        && request.resource.data.classId is string
+        && request.resource.data.className is string
+        && request.resource.data.startAt is timestamp
+        && cooldownOk(request.auth.uid);
+      allow update, delete: if (isSignedIn() && resource.data.userId == request.auth.uid) || isAdmin();
+    }
+
+    // ===== USERS (Final, Simpler Ruleset) =====
+    match /users/{userId} {
+      allow read: if (isSignedIn() && request.auth.uid == userId) || isAdmin();
+
+      // The CREATE rule is working perfectly, so we keep it.
+      allow create: if isSignedIn() && request.auth.uid == userId &&
+        request.resource.data.keys().hasOnly(['email', 'displayName', 'photoURL', 'createdAt']);
+
+      // A more direct UPDATE rule that avoids diff().
+      allow update: if isSignedIn() && request.auth.uid == userId &&
+        // This rule allows the update ONLY IF the critical fields are NOT changed.
+        request.resource.data.email == resource.data.email &&
+        request.resource.data.createdAt == resource.data.createdAt;
+    }
+
+    // ===== ATTENDANCE (admin-only) =====
+    match /attendance/{doc} {
+      allow read, write: if isAdmin();
+    }
+
+    // ===== SCHEDULE TEMPLATE =====
+    match /schedule_template/{doc} {
+      allow read: if true;
+      allow write: if isAdmin();
+    }
+
+    // ===== Everything else locked =====
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -594,11 +594,18 @@
             const uid = state.currentUser.uid;
             const classRef = db.collection('classes').doc(classId);
             const bookingRef = db.collection('bookings').doc(`${classId}_${uid}`);
+            const userRef = db.collection('users').doc(uid);
             try{
               await db.runTransaction(async tx=>{
-                const [classSnap, bookingSnap] = await Promise.all([tx.get(classRef), tx.get(bookingRef)]);
+                const [classSnap, bookingSnap, userSnap] = await Promise.all([
+                  tx.get(classRef), tx.get(bookingRef), tx.get(userRef)
+                ]);
                 if (!classSnap.exists) throw new Error('La clase ya no existe.');
                 if (bookingSnap.exists) throw new Error('Ya tienes reserva para esta clase.');
+                const lastCancelAt = userSnap.exists ? asDate(userSnap.data().lastCancelAt) : null;
+                if (lastCancelAt && Date.now() - lastCancelAt.getTime() < 15*60*1000) {
+                  throw new Error('Debes esperar 15 minutos después de cancelar para reservar de nuevo.');
+                }
                 const cls = classSnap.data();
                 const enrolled = Number(cls.enrolledCount||0);
                 const capacity = Number(cls.capacity||0);
@@ -620,18 +627,24 @@
             }catch(err){ alert(`No se pudo reservar\n\n${err.message}`); }
           },
           cancelBooking: async (classId)=>{
+            if (!confirm('Si cancelas deberás esperar 15 minutos para volver a reservar. ¿Deseas continuar?')) return;
             const uid = state.currentUser.uid;
             const classRef = db.collection('classes').doc(classId);
             const bookingRef = db.collection('bookings').doc(`${classId}_${uid}`);
+            const userRef = db.collection('users').doc(uid);
             try{
               await db.runTransaction(async tx=>{
-                const [bookingSnap, classSnap] = await Promise.all([tx.get(bookingRef), tx.get(classRef)]);
+                const [bookingSnap, classSnap] = await Promise.all([
+                  tx.get(bookingRef), tx.get(classRef)
+                ]);
+                await tx.get(userRef);
                 if (!bookingSnap.exists) throw new Error('No tienes reserva para esta clase.');
                 tx.delete(bookingRef);
                 if (classSnap.exists){
                   const enrolled = Number(classSnap.data().enrolledCount||0);
                   if (enrolled>0) tx.update(classRef,{ enrolledCount: firebase.firestore.FieldValue.increment(-1) });
                 }
+                tx.set(userRef, { lastCancelAt: firebase.firestore.FieldValue.serverTimestamp() }, { merge: true });
               });
               showModal({ success:false, title:'Cancelación Exitosa' });
             }catch(err){ alert(`No se pudo cancelar\n\n${err.message}`); }


### PR DESCRIPTION
## Summary
- Warn users they must wait 15 minutes after canceling and record `lastCancelAt` on cancel
- Block new bookings when a recent cancellation exists
- Enforce cooldown server-side in Firestore security rules

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b68e6ccee88320903612489a0ab9d1