### PR TITLE
Sanitize user-controlled HTML to prevent XSS

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
@@ -195,13 +196,15 @@
           const wrap = document.getElementById('toast-container');
           const el = document.createElement('div');
           el.className = 'toast max-w-md mx-auto bg-zinc-800 border border-zinc-700 rounded-xl p-4 shadow-lg flex items-start gap-3';
+          const safeTitle = DOMPurify.sanitize(title);
+          const safeMessage = DOMPurify.sanitize(message);
           el.innerHTML = `
             <div class="w-10 h-10 rounded-lg bg-${color}-500/20 text-${color}-300 flex items-center justify-center shrink-0">
               <i data-lucide="${variant==='error'?'alert-triangle':variant==='warn'?'alert-circle':'check'}" class="w-6 h-6"></i>
             </div>
             <div class="flex-1">
-              <p class="font-semibold">${title}</p>
-              ${message?`<p class="text-sm text-zinc-400 mt-0.5">${message}</p>`:''}
+              <p class="font-semibold">${safeTitle}</p>
+              ${safeMessage?`<p class="text-sm text-zinc-400 mt-0.5">${safeMessage}</p>`:''}
             </div>
             <button class="shrink-0 text-zinc-400 hover:text-zinc-200" aria-label="Cerrar notificación">
               <i data-lucide="x" class="w-5 h-5"></i>
@@ -412,18 +415,22 @@
             const card = document.createElement('div');
             card.className = `p-4 rounded-lg shadow-md cursor-pointer hover:bg-zinc-700 transition-colors ${style}`;
             card.setAttribute('role','button');
-            card.setAttribute('aria-label', `Editar ${cls.name} a las ${cls.time}`);
+            const safeName = DOMPurify.sanitize(cls.name || '');
+            const safeInstructor = DOMPurify.sanitize(cls.instructor || '');
+            const safeIcon = DOMPurify.sanitize(cls.icon || '💪');
+            const safeTime = DOMPurify.sanitize(cls.time || '');
+            card.setAttribute('aria-label', `Editar ${safeName} a las ${safeTime}`);
             card.onclick = () => this.showClassModal(cls);
             card.innerHTML = `
               <div class="flex justify-between items-start">
                 <div>
-                  <p class="text-xl font-bold">${cls.name}</p>
-                  <p class="text-sm text-zinc-400">${cls.instructor}</p>
+                  <p class="text-xl font-bold">${safeName}</p>
+                  <p class="text-sm text-zinc-400">${safeInstructor}</p>
                 </div>
-                <span class="text-2xl">${cls.icon || '💪'}</span>
+                <span class="text-2xl">${safeIcon}</span>
               </div>
               <div class="mt-4 flex justify-between items-center text-sm">
-                <span class="font-semibold">a las ${cls.time}</span>
+                <span class="font-semibold">a las ${safeTime}</span>
                 <span class="font-bold ${enrolled>=capacity?'text-rose-400':'text-white'}">${enrolled} / ${capacity}</span>
               </div>`;
             if (cls.classDate === this.dateHelper.today()) todayC.appendChild(card);
@@ -446,10 +453,12 @@
               const attendees = (this.state.bookingsMap.get(cls.id)||[]).map(b=>b.userName||'Anónimo');
               const enrolled = Number(cls.enrolledCount||0);
               const cap = Number(cls.capacity||0);
-              const names = attendees.map(n=>`<li class="text-zinc-400 ml-4">- ${n}</li>`).join('');
+              const names = attendees.map(n=>`<li class="text-zinc-400 ml-4">- ${DOMPurify.sanitize(n)}</li>`).join('');
+              const safeTime = DOMPurify.sanitize(cls.time || '');
+              const safeName = DOMPurify.sanitize(cls.name || '');
               return `
                 <div class="mb-3">
-                  <p class="font-bold">${cls.time} - ${cls.name} (${enrolled} de ${cap})</p>
+                  <p class="font-bold">${safeTime} - ${safeName} (${enrolled} de ${cap})</p>
                   <ul class="list-none">${names}</ul>
                 </div>`;
             });
@@ -585,10 +594,13 @@
           const renderList = (obj)=>{
             const names = Object.keys(obj||{}).sort();
             if (!names.length) return '<ul class="list-disc list-inside text-zinc-400"><li>Nadie</li></ul>';
-            return names.map(n=>`
-              <div class="font-semibold text-zinc-300 mt-1">${n}:</div>
-              <ul class="list-disc list-inside text-zinc-400">${(obj[n]||[]).map(p=>`<li>${p}</li>`).join('')}</ul>
-            `).join('');
+            return names.map(n=>{
+              const safeName = DOMPurify.sanitize(n);
+              const people = (obj[n]||[]).map(p=>`<li>${DOMPurify.sanitize(p)}</li>`).join('');
+              return `
+              <div class="font-semibold text-zinc-300 mt-1">${safeName}:</div>
+              <ul class="list-disc list-inside text-zinc-400">${people}</ul>
+            `;}).join('');
           };
 
           details.innerHTML = keys.map(k=>{
@@ -596,14 +608,14 @@
             if (k!=='tomorrow'){
               return `
                 <div class="bg-zinc-900 p-3 rounded-md">
-                  <h4 class="font-bold text-lg mb-2">${dates[k].label}</h4>
+                  <h4 class="font-bold text-lg mb-2">${DOMPurify.sanitize(dates[k].label)}</h4>
                   <div class="font-semibold text-emerald-400">Asistieron (${d.attended||0})</div>${renderList(d.details.attended)}
                   <div class="font-semibold text-rose-400 mt-2">Faltaron (${d.absent||0})</div>${renderList(d.details.absent)}
                 </div>`;
             }
             return `
               <div class="bg-zinc-900 p-3 rounded-md">
-                <h4 class="font-bold text-lg mb-2">${dates[k].label}</h4>
+                <h4 class="font-bold text-lg mb-2">${DOMPurify.sanitize(dates[k].label)}</h4>
                 <div class="font-semibold text-blue-400">Reservaron (${d.booked||0})</div>${renderList(d.details.booked)}
               </div>`;
           }).join('');
@@ -700,10 +712,12 @@
             const st = existing[b.userId];
             const selA = st==='attended' ? 'selected-attended':'';
             const selF = st==='absent'   ? 'selected-absent':'';
+            const safeName = DOMPurify.sanitize(b.userName || 'Anónimo');
+            const safeId = DOMPurify.sanitize(b.userId);
             return `
               <div class="flex items-center justify-between bg-zinc-900 p-2 rounded-md">
-                <span class="text-zinc-300">${b.userName||'Anónimo'}</span>
-                <div class="space-x-2" data-user-id="${b.userId}" data-user-name="${b.userName||'Anónimo'}">
+                <span class="text-zinc-300">${safeName}</span>
+                <div class="space-x-2" data-user-id="${safeId}" data-user-name="${safeName}">
                   <button class="attendance-btn border border-zinc-600 px-3 py-1 text-xs rounded-md ${selA}" data-status="attended">Asistió</button>
                   <button class="attendance-btn border border-zinc-600 px-3 py-1 text-xs rounded-md ${selF}" data-status="absent">Faltó</button>
                 </div>
@@ -852,33 +866,39 @@
         userCardHTML(userDoc, indexBase=0){
           const userData = userDoc.data() || {};
           const tokens = userData.fcmTokens ? Object.keys(userData.fcmTokens) : [];
+          const safeName = DOMPurify.sanitize(userData.displayName || 'Usuario sin nombre');
+          const safeEmail = DOMPurify.sanitize(userData.email || '');
           const head = `
             <div class="p-4 bg-zinc-700/50 rounded-lg">
-              <h4 class="font-bold">${userData.displayName || 'Usuario sin nombre'}</h4>
-              <p class="text-sm text-zinc-400">${userData.email || ''}</p>
+              <h4 class="font-bold">${safeName}</h4>
+              <p class="text-sm text-zinc-400">${safeEmail}</p>
           `;
           if (!tokens.length){
             return head + `<p class="text-sm text-zinc-400 mt-3">Sin dispositivos registrados.</p></div>`;
           }
-          const bodies = tokens.map((token,i)=>`
+          const bodies = tokens.map((token,i)=>{
+            const safeToken = DOMPurify.sanitize(token);
+            const displayToken = DOMPurify.sanitize(safeToken.substring(0,30));
+            const safeUid = DOMPurify.sanitize(userDoc.id);
+            return `
             <div class="p-3 bg-zinc-900 rounded-lg border border-zinc-700 mt-3">
-              <p class="text-xs text-zinc-400 font-mono break-all">Dispositivo ${i+1}: ${token.substring(0,30)}...</p>
+              <p class="text-xs text-zinc-400 font-mono break-all">Dispositivo ${i+1}: ${displayToken}...</p>
               <div class="mt-3 space-y-2">
                 <input type="text" id="noti-title-${indexBase}_${i}" class="w-full bg-zinc-700 text-white p-2 rounded-md text-sm" placeholder="Título de la notificación">
                 <textarea id="noti-body-${indexBase}_${i}" class="w-full bg-zinc-700 text-white p-2 rounded-md text-sm h-16" placeholder="Cuerpo del mensaje"></textarea>
                 <div class="flex gap-2">
-                  <button data-token="${token}" data-index="${indexBase}_${i}" data-uid="${userDoc.id}"
+                  <button data-token="${safeToken}" data-index="${indexBase}_${i}" data-uid="${safeUid}"
                           class="send-noti-btn flex-1 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 rounded-md text-sm">
                     Enviar a este Dispositivo
                   </button>
-                  <button data-token="${token}" data-uid="${userDoc.id}"
+                  <button data-token="${safeToken}" data-uid="${safeUid}"
                           class="prune-token-btn px-3 bg-zinc-700 hover:bg-zinc-600 text-white font-semibold rounded-md text-sm">
                     Prune
                   </button>
                 </div>
               </div>
             </div>
-          `).join('');
+          `;}).join('');
           return head + `<div class="mt-4 space-y-3">${bodies}</div></div>`;
         },
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <!-- Tailwind + Lucide + Fuente -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 
@@ -428,17 +429,20 @@
             const hhmm = b.time || new Intl.DateTimeFormat('es-MX',{hour:'2-digit',minute:'2-digit',hour12:false}).format(startObj);
             const dayText = ymd===dateHelper.today ? 'Hoy' : ymd===dateHelper.tomorrow ? 'Mañana' : dateHelper.human(ymd);
             const cover = coverHelper.forClassName(b.className, b.className);
+            const safeClassName = DOMPurify.sanitize(b.className || '');
+            const safeDayText = DOMPurify.sanitize(dayText);
+            const safeClassId = DOMPurify.sanitize(b.classId);
             return `
               <div class="bg-zinc-800 rounded-2xl p-4 flex items-center justify-between">
                 <div class="flex items-center gap-4">
-                  <img src="${cover}" alt="${b.className}" class="w-16 h-16 rounded-lg object-cover bg-zinc-700" loading="lazy" decoding="async">
+                  <img src="${cover}" alt="${safeClassName}" class="w-16 h-16 rounded-lg object-cover bg-zinc-700" loading="lazy" decoding="async">
                   <div>
-                    <p class="font-bold text-lg">${b.className}</p>
-                    <p class="text-zinc-400 text-sm">${dayText} • ${hhmm}</p>
+                    <p class="font-bold text-lg">${safeClassName}</p>
+                    <p class="text-zinc-400 text-sm">${safeDayText} • ${hhmm}</p>
                     <p class="text-emerald-400 text-xs mt-0.5">${timeUntilLabel(ymd, hhmm)}</p>
                   </div>
                 </div>
-                <button data-action="cancel-booking" data-class-id="${b.classId}" class="text-xs text-rose-400 hover:text-rose-300">Cancelar</button>
+                <button data-action="cancel-booking" data-class-id="${safeClassId}" class="text-xs text-rose-400 hover:text-rose-300">Cancelar</button>
               </div>`;
           }).join('') : `<div class="bg-zinc-800 rounded-2xl p-5 text-center text-zinc-400">No tienes reservas próximas.</div>`;
 
@@ -463,12 +467,15 @@
             else if (available<=0) badge = `<span class="text-xs bg-rose-500/50 text-rose-300 px-2 py-1 rounded-md">Llena</span>`;
             const ymd = cls.classDate || targetYMD;
             const hhmm = cls.time || new Date(cls.startAt.toDate()).toLocaleTimeString('es-MX',{hour:'2-digit',minute:'2-digit',hour12:false});
+            const safeName = DOMPurify.sanitize(cls.name || '');
+            const safeInstructor = DOMPurify.sanitize(cls.instructor || '');
+            const safeId = DOMPurify.sanitize(cls.id);
             return `
-              <div data-action="navigate-details" data-class-id="${cls.id}" class="bg-zinc-800 rounded-2xl p-4 flex items-center gap-4 cursor-pointer hover:bg-zinc-700">
-                <img src="${coverHelper.forClass(cls)}" alt="${cls.name}" class="w-16 h-16 rounded-lg object-cover bg-zinc-700" loading="lazy" decoding="async">
+              <div data-action="navigate-details" data-class-id="${safeId}" class="bg-zinc-800 rounded-2xl p-4 flex items-center gap-4 cursor-pointer hover:bg-zinc-700">
+                <img src="${coverHelper.forClass(cls)}" alt="${safeName}" class="w-16 h-16 rounded-lg object-cover bg-zinc-700" loading="lazy" decoding="async">
                 <div class="flex-1">
-                  <p class="font-bold text-lg">${cls.name}</p>
-                  <p class="text-zinc-400 text-sm">con ${cls.instructor}</p>
+                  <p class="font-bold text-lg">${safeName}</p>
+                  <p class="text-zinc-400 text-sm">con ${safeInstructor}</p>
                   <p class="text-sm mt-1 text-emerald-400">${hhmm} hrs</p>
                   <p class="text-emerald-300 text-xs mt-0.5">${timeUntilLabel(ymd, hhmm)}</p>
                 </div>
@@ -500,11 +507,15 @@
         }
 
         function getProfileScreenHTML(){
+          const safeDisplay = DOMPurify.sanitize(state.currentUser.displayName || '');
+          const safeEmail = DOMPurify.sanitize(state.currentUser.email || '');
+          const nameForText = safeDisplay || safeEmail;
+          const placeholder = (nameForText.charAt(0) || 'U').toUpperCase();
           return `
             <div class="p-6 space-y-6">
               <header class="text-center space-y-4">
-                <img src="${state.currentUser.photoURL || `https://placehold.co/100x100/18181b/ffffff?text=${(state.currentUser.displayName || state.currentUser.email).charAt(0).toUpperCase()}`}" class="w-24 h-24 rounded-full mx-auto border-4 border-zinc-700">
-                <div><h1 class="text-2xl font-bold">${state.currentUser.displayName || state.currentUser.email}</h1></div>
+                <img src="${state.currentUser.photoURL || `https://placehold.co/100x100/18181b/ffffff?text=${placeholder}`}" class="w-24 h-24 rounded-full mx-auto border-4 border-zinc-700">
+                <div><h1 class="text-2xl font-bold">${nameForText}</h1></div>
               </header>
               <div class="bg-zinc-800 rounded-2xl p-4 divide-y divide-zinc-700">
                 <a href="#" data-action="edit-name" class="flex items-center justify-between py-3">
@@ -530,23 +541,26 @@
           const ymd = cls.classDate || dateHelper.getYYYYMMDD(cls.startAt.toDate());
           const hhmm = cls.time || new Date(cls.startAt.toDate()).toLocaleTimeString('es-MX',{hour:'2-digit',minute:'2-digit',hour12:false});
           const timeRange = timeHelper.range(ymd, hhmm, durationMin);
-          let buttonHTML = `<button data-action="confirm-booking" data-class-id="${cls.id}" class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-4 rounded-xl">Reservar Ahora</button>`;
+          const safeName = DOMPurify.sanitize(cls.name || '');
+          const safeDesc = DOMPurify.sanitize(cls.description || '');
+          const safeId = DOMPurify.sanitize(cls.id);
+          let buttonHTML = `<button data-action="confirm-booking" data-class-id="${safeId}" class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-4 rounded-xl">Reservar Ahora</button>`;
           if (isBooked) buttonHTML = `<button class="w-full bg-zinc-700 text-zinc-400 font-bold py-4 rounded-xl" disabled>Ya estás inscrito</button>`;
           else if (availableSpots<=0) buttonHTML = `<button class="w-full bg-rose-800 text-rose-400 font-bold py-4 rounded-xl" disabled>Clase Llena</button>`;
           return `
             <div>
               <div class="relative">
-                <img src="${coverHelper.forClass(cls)}" class="w-full h-64 object-cover">
+                <img src="${coverHelper.forClass(cls)}" class="w-full h-64 object-cover" alt="${safeName}">
                 <button data-action="navigate" data-screen="agenda" class="absolute top-6 left-6 bg-black/50 p-2 rounded-full text-white">
                   <i data-lucide="arrow-left" class="w-6 h-6"></i>
                 </button>
               </div>
               <div class="p-6 space-y-4 pb-40">
                 <h1 class="text-3xl font-bold">
-                  ${cls.name}
+                  ${safeName}
                   <span class="block text-lg font-semibold text-zinc-300 mt-1">${timeRange}</span>
                 </h1>
-                <p class="text-zinc-400 leading-relaxed">${cls.description || ''}</p>
+                <p class="text-zinc-400 leading-relaxed">${safeDesc}</p>
                 <div class="bg-zinc-800 p-4 rounded-xl flex justify-between items-center">
                   <span class="font-semibold text-lg">Estado</span>
                   <span class="text-2xl font-bold ${availableSpots>0?'text-emerald-400':'text-rose-400'}">${availableSpots>0?'¡Hay cupo!':'Llena'}</span>
@@ -677,11 +691,12 @@
         function showModal({success, title}){
           const fabs = document.getElementById('social-fabs');
           if (fabs) fabs.classList.add('opacity-0','pointer-events-none');
+          const safeTitle = DOMPurify.sanitize(title);
           modalContent.innerHTML = `
             <div class="w-16 h-16 ${success?'bg-emerald-500/20 text-emerald-400':'bg-rose-500/20 text-rose-400'} rounded-full flex items-center justify-center mx-auto">
               <i data-lucide="${success?'check':'trash-2'}" class="w-10 h-10"></i>
             </div>
-            <h2 class="text-2xl font-bold">${title}</h2>
+            <h2 class="text-2xl font-bold">${safeTitle}</h2>
             <button id="modal-close-btn" class="w-full bg-indigo-600 text-white font-semibold py-3 rounded-lg mt-4">Entendido</button>`;
           genericModal.classList.remove('hidden');
           setTimeout(()=>modalContent.classList.remove('scale-95','opacity-0'),10);


### PR DESCRIPTION
## Summary
- Add DOMPurify to admin and client pages
- Sanitize toast messages, user cards, and class listings in admin panel
- Escape user-controlled fields in agenda, profile and class detail views

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6929b4d308320af86cf60f2bd2956