### PR TITLE
Show default attendance range from two days ago to tomorrow

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -488,8 +488,9 @@
         // ====== ASISTENCIA (POLLING CADA 15 MIN) ======
         getDefaultAttendanceRange(){
           const end = new Date();
-          const start = new Date();
-          start.setDate(end.getDate()-29);
+          end.setDate(end.getDate()+1);
+          const start = new Date(end);
+          start.setDate(start.getDate()-3);
           return { start: this.dateHelper.ymd(start), end: this.dateHelper.ymd(end) };
         },
         getSelectedAttendanceRange(){


### PR DESCRIPTION
## Summary
- update admin attendance chart to default from two days ago through tomorrow while keeping date range inputs functional

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b69df257c8832099a71f7aa7cf79db