### PR TITLE
Add fallback queries for listing users

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -950,14 +950,24 @@
 
           try{
             let snap;
+            const col = this.db.collection('users');
+
             try{
-              snap = await this.db.collection('users').orderBy('displayNameLower').get();
+              snap = await col.orderBy('displayNameLower').get();
             }catch{
+              snap = null;
+            }
+
+            if (!snap || snap.empty){
               try{
-                snap = await this.db.collection('users').orderBy('emailLower').get();
+                snap = await col.orderBy('emailLower').get();
               }catch{
-                snap = await this.db.collection('users').get();
+                snap = null;
               }
+            }
+
+            if (!snap || snap.empty){
+              snap = await col.get();
             }
 
             if (snap.empty){ this.showToast({ title:'Sin usuarios', variant:'warn' }); return; }


### PR DESCRIPTION
## Summary
- Add sequential fallbacks when listing users: display name, email, then plain collection
- Only warn of missing users after all query options return empty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7da139f6c83209a61e1eeae7753c2