### PR TITLE
Allow cross-origin callable functions

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -35,7 +35,7 @@ async function pruneTokenInUsers(token) {
  * Admin-only: send a direct push notification to a provided FCM token.
  * Auto-prunes token if FCM responds with "not registered" or "invalid".
  */
-exports.sendDirectNotification = onCall({ region: "us-central1" }, async (request) => {
+exports.sendDirectNotification = onCall({ region: "us-central1", cors: true }, async (request) => {
   const auth = request.auth;
   if (!auth) throw new HttpsError("unauthenticated", "Auth required.");
   if (auth.token?.admin !== true) throw new HttpsError("permission-denied", "Admins only.");
@@ -80,7 +80,7 @@ exports.sendDirectNotification = onCall({ region: "us-central1" }, async (reques
  * - Writes `emailLower` = email.toLowerCase()
  * Returns counts.
  */
-exports.backfillEmailLower = onCall({ region: "us-central1" }, async (request) => {
+exports.backfillEmailLower = onCall({ region: "us-central1", cors: true }, async (request) => {
   const auth = request.auth;
   if (!auth) throw new HttpsError("unauthenticated", "Auth required.");
   if (auth.token?.admin !== true) throw new HttpsError("permission-denied", "Admins only.");
@@ -125,7 +125,7 @@ exports.backfillEmailLower = onCall({ region: "us-central1" }, async (request) =
  * Optionally pass `overrideClassId` to target a specific class.
  * Returns success/failure counts and prunes invalid FCM tokens.
  */
-exports.sendManualClassReminder = onCall({ region: "us-central1" }, async (request) => {
+exports.sendManualClassReminder = onCall({ region: "us-central1", cors: true }, async (request) => {
   const auth = request.auth;
   if (!auth) throw new HttpsError("unauthenticated", "Auth required.");
   if (auth.token?.admin !== true) throw new HttpsError("permission-denied", "Admins only.");


### PR DESCRIPTION
## Summary
- enable CORS on callable functions so browser clients can reach them

## Testing
- `npm test`
- `npm --prefix functions test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7db252e00832081e7414b1c1a07c3