### PR TITLE
Fix CORS preflight for manual reminders

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -34,8 +34,12 @@ const CALLABLE_OPTS = {
   region: "us-central1",
   invoker: "public",
   cors: {
+    // Allow requests from any origin and let the platform reflect
+    // the headers requested by the client. Restricting the
+    // allowed headers caused preflight checks to fail when the
+    // Firebase SDK sent additional headers, resulting in CORS
+    // errors in the admin panel.
     origin: true,
-    allowedHeaders: ["Authorization", "Content-Type", "Firebase-Instance-ID-Token"],
   },
 };
 


### PR DESCRIPTION
## Summary
- Allow all request headers in callable Cloud Functions to prevent CORS preflight failures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e2fcd930832095c9901f91b6d6cb