### PR TITLE
fix: properly delete device tokens from user profiles

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1053,7 +1053,7 @@
               if (ok){
                 try{
                   await this.db.collection('users').doc(uid).set({
-                    [`fcmTokens.${token}`]: firebase.firestore.FieldValue.delete()
+                    fcmTokens: { [token]: firebase.firestore.FieldValue.delete() }
                   }, { merge:true });
                   this.showToast({ title:'Token eliminado', message:'Se removió el token inválido.' });
                 }catch(pruneErr){
@@ -1076,7 +1076,7 @@
           btn.disabled = true;
           try{
             await this.db.collection('users').doc(uid).set({
-              [`fcmTokens.${token}`]: firebase.firestore.FieldValue.delete()
+              fcmTokens: { [token]: firebase.firestore.FieldValue.delete() }
             }, { merge:true });
             this.showToast({ title:'Token eliminado' });
             const freshDoc = await this.db.collection('users').doc(uid).get();


### PR DESCRIPTION
## Summary
- ensure admin panel deletes FCM tokens by storing the token key inside `fcmTokens` map when pruning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9cb052b3c832092f6fb277b37e39b