### PR TITLE
refactor: centralize token pruning helper

### DIFF
--- a/functions/lib/pruneTokenInUsers.js
+++ b/functions/lib/pruneTokenInUsers.js
@@ -1,0 +1,33 @@
+const admin = require('firebase-admin');
+
+/**
+ * Remove a bad FCM token from any user doc that has it as
+ *   users/{uid}.fcmTokens.<token> == true
+ *
+ * @param {string} token The FCM token to remove.
+ * @returns {Promise<{prunedDocs: number, error?: string}>}
+ */
+async function pruneTokenInUsers(token) {
+  const db = admin.firestore();
+  try {
+    const fieldPath = `fcmTokens.${token}`;
+    const snap = await db.collection('users').where(fieldPath, '==', true).get();
+    if (snap.empty) return { prunedDocs: 0 };
+
+    const batch = db.batch();
+    snap.forEach((doc) => {
+      batch.set(
+        doc.ref,
+        { [fieldPath]: admin.firestore.FieldValue.delete() },
+        { merge: true }
+      );
+    });
+    await batch.commit();
+    return { prunedDocs: snap.size };
+  } catch (e) {
+    console.error('Failed pruning token in users:', e);
+    return { prunedDocs: 0, error: e?.message };
+  }
+}
+
+module.exports = { pruneTokenInUsers };


### PR DESCRIPTION
## Summary
- extract `pruneTokenInUsers` helper into `lib` for reuse
- import helper in index and reminders to avoid duplicate implementations
- log prune results so both callers handle metadata consistently

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9fc3b73d8832099a827e4c10d0ced