### PR TITLE
Batch class reminders and limit notification concurrency

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -7,7 +7,8 @@
       "name": "functions",
       "dependencies": {
         "firebase-admin": "^12.0.0",
-        "firebase-functions": "^5.0.0"
+        "firebase-functions": "^5.0.0",
+        "p-limit": "^3.1.0"
       },
       "devDependencies": {
         "firebase-functions-test": "^3.1.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,7 +16,8 @@
   "main": "index.js",
   "dependencies": {
     "firebase-admin": "^12.0.0",
-    "firebase-functions": "^5.0.0"
+    "firebase-functions": "^5.0.0",
+    "p-limit": "^3.1.0"
   },
   "devDependencies": {
     "firebase-functions-test": "^3.1.0"


### PR DESCRIPTION
## Summary
- batch Firestore reads for classes, bookings, and notifications
- send per-class push notifications with `sendEachForMulticast`
- limit Firestore and FCM concurrency via `p-limit` and log failures

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fdb61df08320862fdbdbbb3b90f3