### PR TITLE
Add Firestore notifications access rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -62,6 +62,12 @@ service cloud.firestore {
       allow read, write: if isAdmin();
     }
 
+    // ===== NOTIFICATIONS =====
+    match /notifications/{doc} {
+      allow read: if isAdmin();
+      allow write: if false;
+    }
+
     // ===== SCHEDULE TEMPLATE =====
     match /schedule_template/{doc} {
       allow read: if true;


### PR DESCRIPTION
## Summary
- restrict notification reads to admins and block writes

## Testing
- `npm test`
- `firebase deploy --only firestore:rules` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a3301f0832090cbefb7192556a1