### PR TITLE
Log booking reminder notifications

### DIFF
--- a/functions/src/bookingReminders.js
+++ b/functions/src/bookingReminders.js
@@ -75,5 +75,11 @@ exports.sendBookingReminder = onTaskDispatched(
       }
     });
     await Promise.all(prunePromises);
+    await db.collection('notifications').add({
+      classId,
+      userId,
+      interval,
+      sentAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
   }
 );


### PR DESCRIPTION
## Summary
- Log booking reminder notifications to Firestore after tokens are pruned.

## Testing
- `npm test`
- `npm --prefix functions test` *(fails: Missing script "test")*
- `npm run deploy` *(fails: firebase: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0b908874832081035f6c5d49f22b