### PR TITLE
Use accessible toast notifications for push messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,9 @@
       <div id="modal-content" class="bg-zinc-800 rounded-2xl p-6 text-center space-y-6 max-w-sm w-full mx-auto transition-all transform scale-95 opacity-0"></div>
     </div>
 
+    <!-- Toast -->
+    <div id="toast" role="status" tabindex="0" class="fixed bottom-4 left-1/2 -translate-x-1/2 transform bg-zinc-800 text-white px-4 py-2 rounded-lg shadow-lg opacity-0 transition-opacity z-[100]"></div>
+
     <!-- FABs -->
     <div id="social-fabs" class="fixed right-4 flex flex-col gap-3 z-[70] pointer-events-auto" style="bottom: calc(env(safe-area-inset-bottom, 0px) + 5rem);">
       <a href="https://wa.me/5215539887713" target="_blank" rel="noopener noreferrer" class="bg-green-500 hover:bg-green-600 text-white rounded-full p-4 shadow-lg flex items-center justify-center">
@@ -185,6 +188,22 @@
         const appContainer = document.getElementById('app-container');
         const loadingSpinner = document.getElementById('loading-spinner');
         const navBar = document.getElementById('nav-bar');
+        const toastEl = document.getElementById('toast');
+        let toastTimeout;
+        function showToast(message, type = 'info') {
+          if (!toastEl) return;
+          toastEl.textContent = message;
+          toastEl.classList.remove('opacity-0', 'bg-green-600', 'bg-red-600', 'bg-zinc-800');
+          const color = type === 'success' ? 'bg-green-600' : type === 'error' ? 'bg-red-600' : 'bg-zinc-800';
+          toastEl.classList.add(color, 'opacity-100');
+          toastEl.focus();
+          clearTimeout(toastTimeout);
+          toastTimeout = setTimeout(() => {
+            toastEl.classList.remove('opacity-100');
+            toastEl.classList.add('opacity-0');
+          }, 3000);
+        }
+        window.showToast = showToast;
 
         // Firestore listeners
         let unsubClasses=null, unsubMyBookings=null, listenersAttached=false;
@@ -282,7 +301,7 @@
           messaging.onMessage((payload) => {
             const title = payload.notification?.title || payload.data?.title || 'Notificación';
             const body  = payload.notification?.body  || payload.data?.body  || '';
-            alert(`${title}\n${body}`);
+            showToast(`${title}${body ? ': ' + body : ''}`);
           });
           return token;
         }
@@ -398,14 +417,14 @@
             btn.onclick = async () => {
               try{
                 const user = firebase.auth().currentUser;
-                if (!user) return alert('Inicia sesión primero');
-                if (!isPushSupported()) return alert('Este navegador no soporta notificaciones push.');
+                if (!user) return showToast('Inicia sesión primero', 'error');
+                if (!isPushSupported()) return showToast('Este navegador no soporta notificaciones push.', 'error');
                 btn.disabled = true;
                 await ensurePushPermissionAndToken(user);
-                alert('Notificaciones activadas ✅');
+                showToast('Notificaciones activadas ✅', 'success');
               }catch(e){
                 console.error('Enable push failed:', e);
-                alert(e.message || 'No se pudo activar notificaciones');
+                showToast(e.message || 'No se pudo activar notificaciones', 'error');
               }finally{
                 btn.disabled = false;
               }


### PR DESCRIPTION
## Summary
- Add reusable toast component with role="status" and keyboard focus
- Replace alert usage with toast for foreground push messages and enabling push

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba24e9a74083209c6f44a616151cbb