### PR TITLE
Tag notifications per class

### DIFF
--- a/functions/src/bookingReminders.js
+++ b/functions/src/bookingReminders.js
@@ -52,11 +52,12 @@ exports.sendBookingReminder = onTaskDispatched(
 
     const res = await admin.messaging().sendEachForMulticast({
       tokens,
-      notification: {
+      // Use data-only payload so the SW can handle tagging/renotify
+      data: {
         title: classData.title || 'Class Reminder',
         body: `Your class starts in ${interval} minutes`,
+        classId,
       },
-      data: { classId },
     });
 
     const prunePromises = [];

--- a/service-worker.js
+++ b/service-worker.js
@@ -38,18 +38,23 @@ messaging.onBackgroundMessage((payload) => {
 
   const data = payload?.data || {};
   const title = data.title || "Recordatorio de clase";
-  const body  = data.body  || "";
+  const body = data.body || "";
   // MODIFIED: Changed fallback URL to root
-  const url   = data.url   || "/";
+  const url = data.url || "/";
+  // NEW: Extract classId for tagging notifications
+  const classId = data.classId || "";
+  const tag = classId ? `class-${classId}` : undefined;
   // MODIFIED: Changed icon path to root
-  const icon  = "/images/icon-192x192.png";
+  const icon = "/images/icon-192x192.png";
 
-  log("Mostrando notificación manual (data-only):", { title, body, url });
+  log("Mostrando notificación manual (data-only):", { title, body, url, classId });
   self.registration.showNotification(title, {
     body,
     icon,
     badge: icon,
-    data: { url }
+    data: { url, classId },
+    tag,
+    renotify: true,
   });
 });
 


### PR DESCRIPTION
## Summary
- Tag service worker notifications per class and enable renotify to replace duplicates
- Send data-only reminder payloads including classId for client-side tagging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba25fa9f208320a6ed1ff492c66004