### PR TITLE
Render class schedules in Mexico City timezone

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -190,14 +190,14 @@
         },
 
         // --- Helpers ---
-        timeFmt: new Intl.DateTimeFormat('es-MX',{hour:'2-digit',minute:'2-digit'}),
-        dayFmt: new Intl.DateTimeFormat('es-MX',{weekday:'long',day:'2-digit',month:'short'}),
-        dayShortFmt: new Intl.DateTimeFormat('es-MX',{day:'2-digit',month:'short'}),
+        timeFmt: new Intl.DateTimeFormat('es-MX',{ timeZone: 'America/Mexico_City', hour:'2-digit',minute:'2-digit',hour12:false }),
+        dayFmt: new Intl.DateTimeFormat('es-MX',{ timeZone: 'America/Mexico_City', weekday:'long',day:'2-digit',month:'short' }),
+        dayShortFmt: new Intl.DateTimeFormat('es-MX',{ timeZone: 'America/Mexico_City', day:'2-digit',month:'short' }),
         dateHelper: {
-          ymd(date){ const y=date.getFullYear(),m=String(date.getMonth()+1).padStart(2,'0'),d=String(date.getDate()).padStart(2,'0'); return `${y}-${m}-${d}`; },
+          ymd(date){ return new Intl.DateTimeFormat('en-CA',{ timeZone: 'America/Mexico_City', year:'numeric', month:'2-digit', day:'2-digit' }).format(date); },
           today(){ return this.ymd(new Date()); },
-          tomorrow(){ const t=new Date(); t.setDate(t.getDate()+1); return this.ymd(t); },
-          yesterday(){ const t=new Date(); t.setDate(t.getDate()-1); return this.ymd(t); }
+          tomorrow(){ return this.ymd(new Date(Date.now()+86400000)); },
+          yesterday(){ return this.ymd(new Date(Date.now()-86400000)); }
         },
         normalizeStr(s=''){
           return s.normalize('NFD').replace(/[\u0300-\u036f]/g,'').toLowerCase().trim();
@@ -315,7 +315,15 @@
             .where('classDate', 'in', [yesterday, today, tomorrow])
             .orderBy('classDate','asc').orderBy('time','asc')
             .onSnapshot((snap)=>{
-              this.state.classes = snap.docs.map(d=>({ id:d.id, ...d.data() }));
+              this.state.classes = snap.docs.map(d=>{
+                const data = { id:d.id, ...d.data() };
+                if (data.classDate && data.time){
+                  const start = new Date(`${data.classDate}T${data.time}:00Z`);
+                  data.localDate = this.dateHelper.ymd(start);
+                  data.localTime = this.timeFmt.format(start);
+                }
+                return data;
+              });
               this.mountBookingsListenersForVisibleClasses();
               this.renderAll();
               this.renderAttendanceChartFromCache();
@@ -383,11 +391,13 @@
 
         // --- GENERACIÓN (startAt/endAt) ---
         _buildStartEnd(dateStr, timeStr, duration=60){
-          const start = new Date(`${dateStr}T${timeStr}:00`);
+          const start = new Date(`${dateStr}T${timeStr}:00-06:00`);
           const end = new Date(start.getTime() + (Number(duration||60)*60000));
           return {
             startAt: firebase.firestore.Timestamp.fromDate(start),
-            endAt: firebase.firestore.Timestamp.fromDate(end)
+            endAt: firebase.firestore.Timestamp.fromDate(end),
+            classDate: start.toISOString().slice(0,10),
+            timeUTC: start.toISOString().slice(11,16)
           };
         },
 
@@ -409,19 +419,19 @@
             const tpl = this.state.weeklySchedule[String(d.dow)] || [];
             if (!tpl.length) continue;
             const existingSnap = await this.db.collection('classes').where('classDate','==',d.dateStr).get();
-            const existingTimes = new Set(existingSnap.docs.map(x=>x.data().time));
+            const existingTimes = new Set(existingSnap.docs.map(x=> this.timeFmt.format(new Date(`${d.dateStr}T${x.data().time}:00Z`)) ));
             for (const c of tpl){
               if (!existingTimes.has(c.time)){
                 const ref = this.db.collection('classes').doc();
-                const { startAt, endAt } = this._buildStartEnd(d.dateStr, c.time, c.duration||60);
+                const { startAt, endAt, classDate, timeUTC } = this._buildStartEnd(d.dateStr, c.time, c.duration||60);
                 const isTRX = /trx/i.test(c.name || "");
                 const capacity = (typeof c.capacity === "number") ? c.capacity : (isTRX ? 13 : 15);
                 batch.set(ref,{
                   name: c.name,
-                  time: c.time,
+                  time: timeUTC,
                   instructor: c.instructor || 'Por Asignar',
                   duration: c.duration || 60,
-                  classDate: d.dateStr,
+                  classDate,
                   capacity,
                   enrolledCount: 0,
                   startAt,
@@ -447,10 +457,10 @@
         renderAll(){ this.renderClassCards(); this.renderDailyBookings(); },
 
         isClassRunningNow(cls){
-          if (!cls || !cls.classDate) return false;
+          if (!cls || !cls.classDate || !cls.time) return false;
           const todayStr = this.dateHelper.today();
-          if (cls.classDate !== todayStr) return false;
-          const start = new Date(`${cls.classDate}T${cls.time}:00`).getTime();
+          if (cls.localDate !== todayStr) return false;
+          const start = new Date(`${cls.classDate}T${cls.time}:00Z`).getTime();
           const end   = start + (Number(cls.duration||60)*60000);
           const now = Date.now();
           return now>=start && now<=end;
@@ -461,7 +471,11 @@
           const tomorrowC = document.getElementById('tomorrow-classes-container');
           todayC.innerHTML=''; tomorrowC.innerHTML='';
 
-          const sorted = [...this.state.classes].sort((a,b)=>(a.classDate+a.time).localeCompare(b.classDate+b.time));
+          const sorted = [...this.state.classes].sort((a,b)=>{
+            const sa = new Date(`${a.classDate}T${a.time}:00Z`).getTime();
+            const sb = new Date(`${b.classDate}T${b.time}:00Z`).getTime();
+            return sa - sb;
+          });
           for (const cls of sorted){
             const isRunning = this.isClassRunningNow(cls);
             const style = isRunning ? 'bg-emerald-900 border border-emerald-600' : 'bg-zinc-800';
@@ -473,7 +487,7 @@
             const safeName = DOMPurify.sanitize(cls.name || '');
             const safeInstructor = DOMPurify.sanitize(cls.instructor || '');
             const safeIcon = DOMPurify.sanitize(cls.icon || '💪');
-            const safeTime = DOMPurify.sanitize(cls.time || '');
+            const safeTime = DOMPurify.sanitize(cls.localTime || cls.time || '');
             card.setAttribute('aria-label', `Editar ${safeName} a las ${safeTime}`);
             card.onclick = () => this.showClassModal(cls);
             card.innerHTML = `
@@ -488,8 +502,8 @@
                 <span class="font-semibold">a las ${safeTime}</span>
                 <span class="font-bold ${enrolled>=capacity?'text-rose-400':'text-white'}">${enrolled} / ${capacity}</span>
               </div>`;
-            if (cls.classDate === this.dateHelper.today()) todayC.appendChild(card);
-            else if (cls.classDate === this.dateHelper.tomorrow()) tomorrowC.appendChild(card);
+            if (cls.localDate === this.dateHelper.today()) todayC.appendChild(card);
+            else if (cls.localDate === this.dateHelper.tomorrow()) tomorrowC.appendChild(card);
           }
           if (!todayC.children.length) todayC.innerHTML = '<p class="text-zinc-500 col-span-full">No hay clases programadas para hoy.</p>';
           if (!tomorrowC.children.length) tomorrowC.innerHTML = '<p class="text-zinc-500 col-span-full">No hay clases programadas para mañana.</p>';
@@ -501,7 +515,7 @@
           todayList.innerHTML=''; tomList.innerHTML='';
 
           const byDate = { [this.dateHelper.today()]:[], [this.dateHelper.tomorrow()]:[] };
-          this.state.classes.forEach(c=>{ if(byDate[c.classDate]) byDate[c.classDate].push(c); });
+          this.state.classes.forEach(c=>{ if(byDate[c.localDate]) byDate[c.localDate].push(c); });
 
           const buildHTML = (classesArr)=>{
             const blocks = classesArr.map(cls=>{
@@ -509,7 +523,7 @@
               const enrolled = Number(cls.enrolledCount||0);
               const cap = Number(cls.capacity||0);
               const names = attendees.map(n=>`<li class="text-zinc-400 ml-4">- ${DOMPurify.sanitize(n)}</li>`).join('');
-              const safeTime = DOMPurify.sanitize(cls.time || '');
+              const safeTime = DOMPurify.sanitize(cls.localTime || cls.time || '');
               const safeName = DOMPurify.sanitize(cls.name || '');
               return `
                 <div class="mb-3">
@@ -722,7 +736,7 @@
         // --- MODAL / Asistencia ---
         isClassInProgressWindow(cls){
           if (!cls || !cls.classDate || !cls.time) return false;
-          const start = new Date(`${cls.classDate}T${cls.time}:00`).getTime();
+          const start = new Date(`${cls.classDate}T${cls.time}:00Z`).getTime();
           const now = Date.now();
           const lower = now - (15*60*60*1000);
           const upper = now + (30*60*1000);
@@ -734,7 +748,7 @@
           document.getElementById('class-id').value = cls.id;
           document.getElementById('class-name').value = cls.name || '';
           document.getElementById('class-instructor').value = cls.instructor || '';
-          document.getElementById('class-time').value = cls.time || '';
+          document.getElementById('class-time').value = cls.localTime || cls.time || '';
           document.getElementById('class-icon').value = cls.icon || '';
           document.getElementById('class-description').value = cls.description || '';
 
@@ -1133,9 +1147,13 @@
           };
           try{
             const cls = this.state.classes.find(c=>c.id===id);
-            if (cls && data.time && data.time !== cls.time){
-              const { startAt, endAt } = this._buildStartEnd(cls.classDate, data.time, cls.duration||60);
-              data.startAt = startAt; data.endAt = endAt;
+            if (cls && data.time && data.time !== (cls.localTime || cls.time)){
+              const start = new Date(`${cls.localDate||cls.classDate}T${data.time}:00-06:00`);
+              const end = new Date(start.getTime() + (Number(cls.duration||60)*60000));
+              data.startAt = firebase.firestore.Timestamp.fromDate(start);
+              data.endAt = firebase.firestore.Timestamp.fromDate(end);
+              data.classDate = start.toISOString().slice(0,10);
+              data.time = start.toISOString().slice(11,16);
             }
             await this.db.collection('classes').doc(id).set(data,{ merge:true });
             this.showToast({ title:'Clase actualizada' });

--- a/index.html
+++ b/index.html
@@ -105,30 +105,30 @@
         }
 
         // ---- Helpers (fechas, UI, etc.)
+        const MX_TZ = 'America/Mexico_City';
+        const ymdFmt = new Intl.DateTimeFormat('en-CA',{ timeZone: MX_TZ, year:'numeric', month:'2-digit', day:'2-digit' });
+        const timeFmt = new Intl.DateTimeFormat('es-MX',{ timeZone: MX_TZ, hour:'2-digit', minute:'2-digit', hour12:false });
         const dateHelper = {
-          pad(n){ return String(n).padStart(2,'0'); },
-          getYYYYMMDD(date){ return `${date.getFullYear()}-${this.pad(date.getMonth()+1)}-${this.pad(date.getDate())}`; },
+          getYYYYMMDD(date){ return ymdFmt.format(date); },
           get today(){ return this.getYYYYMMDD(new Date()); },
-          get tomorrow(){ const d=new Date(); d.setDate(d.getDate()+1); return this.getYYYYMMDD(d); },
+          get tomorrow(){ return this.getYYYYMMDD(new Date(Date.now()+86400000)); },
           human(ymd){
-            const [y,m,d]=ymd.split('-').map(n=>parseInt(n,10));
-            const dt=new Date(y,m-1,d);
-            return dt.toLocaleDateString('es-MX',{weekday:'long',day:'2-digit',month:'short'});
+            const dt=new Date(`${ymd}T00:00:00Z`);
+            return dt.toLocaleDateString('es-MX',{ timeZone: MX_TZ, weekday:'long',day:'2-digit',month:'short' });
           }
         };
         const timeHelper = {
           range(ymd, hhmm, durationMin=60){
-            const start=new Date(`${ymd}T${hhmm}:00`);
+            const start=new Date(`${ymd}T${hhmm}:00Z`);
             const end=new Date(start.getTime()+Number(durationMin||60)*60000);
-            const fmt=new Intl.DateTimeFormat('es-MX',{hour:'2-digit',minute:'2-digit',hour12:false});
-            return `${fmt.format(start)}–${fmt.format(end)}`;
+            return `${timeFmt.format(start)}–${timeFmt.format(end)}`;
           }
         };
         const asDate = (x) => x?.toDate ? x.toDate() : new Date(x);
 
         function timeUntilLabel(ymd, hhmm){
           if(!ymd||!hhmm) return '';
-          const start=new Date(`${ymd}T${hhmm}:00`).getTime();
+          const start=new Date(`${ymd}T${hhmm}:00Z`).getTime();
           const now=Date.now();
           const diff=start-now;
           if (diff>4*60*60*1000) return '';
@@ -446,18 +446,20 @@
         // --- AGENDA (igual que tu implementación, con mínimos cambios)
         function getAgendaScreenHTML(){
           const upcoming = state.myBookings.filter(Boolean).filter(b=>{
-            const startObj = b.startAt ? asDate(b.startAt) : new Date(`${b.classDate}T${b.time||'00:00'}:00`);
+            const startObj = b.startAt ? asDate(b.startAt) : new Date(`${b.classDate}T${b.time||'00:00'}:00Z`);
             return Date.now() <= startObj.getTime()+5*60*1000;
           }).sort((a,b)=>{
-            const ta = a.startAt ? asDate(a.startAt).getTime() : new Date(`${a.classDate}T${a.time||'00:00'}:00`).getTime();
-            const tb = b.startAt ? asDate(b.startAt).getTime() : new Date(`${b.classDate}T${b.time||'00:00'}:00`).getTime();
+            const ta = a.startAt ? asDate(a.startAt).getTime() : new Date(`${a.classDate}T${a.time||'00:00'}:00Z`).getTime();
+            const tb = b.startAt ? asDate(b.startAt).getTime() : new Date(`${b.classDate}T${b.time||'00:00'}:00Z`).getTime();
             return ta - tb;
           });
           const reservasHTML = upcoming.length ? upcoming.map(b=>{
-            const startObj = b.startAt ? asDate(b.startAt) : new Date(`${b.classDate}T${b.time||'00:00'}:00`);
-            const ymd = b.classDate || dateHelper.getYYYYMMDD(startObj);
-            const hhmm = b.time || new Intl.DateTimeFormat('es-MX',{hour:'2-digit',minute:'2-digit',hour12:false}).format(startObj);
-            const dayText = ymd===dateHelper.today ? 'Hoy' : ymd===dateHelper.tomorrow ? 'Mañana' : dateHelper.human(ymd);
+            const startObj = b.startAt ? asDate(b.startAt) : new Date(`${b.classDate}T${b.time||'00:00'}:00Z`);
+            const ymdUTC = b.classDate || startObj.toISOString().slice(0,10);
+            const hhmmUTC = b.time || startObj.toISOString().slice(11,16);
+            const hhmm = timeFmt.format(startObj);
+            const ymdLocal = dateHelper.getYYYYMMDD(startObj);
+            const dayText = ymdLocal===dateHelper.today ? 'Hoy' : ymdLocal===dateHelper.tomorrow ? 'Mañana' : dateHelper.human(ymdLocal);
             const cover = coverHelper.forClassName(b.className, b.className);
             const safeClassName = DOMPurify.sanitize(b.className || '');
             const safeDayText = DOMPurify.sanitize(dayText);
@@ -469,7 +471,7 @@
                   <div>
                     <p class="font-bold text-lg">${safeClassName}</p>
                     <p class="text-zinc-400 text-sm">${safeDayText} • ${hhmm}</p>
-                    <p class="text-emerald-400 text-xs mt-0.5">${timeUntilLabel(ymd, hhmm)}</p>
+                    <p class="text-emerald-400 text-xs mt-0.5">${timeUntilLabel(ymdUTC, hhmmUTC)}</p>
                   </div>
                 </div>
                 <button data-action="cancel-booking" data-class-id="${safeClassId}" class="text-xs text-rose-400 hover:text-rose-300">Cancelar</button>
@@ -479,13 +481,14 @@
           const targetYMD = state.scheduleFilter==='today' ? dateHelper.today : dateHelper.tomorrow;
           const filtered = state.classes
             .filter(cls=>{
-              const ymd = dateHelper.getYYYYMMDD(cls.startAt?.toDate ? cls.startAt.toDate() : new Date(cls.startAt));
+              const start = cls.startAt?.toDate ? cls.startAt.toDate() : new Date(`${cls.classDate}T${cls.time}:00Z`);
+              const ymd = dateHelper.getYYYYMMDD(start);
               return ymd===targetYMD;
             })
             .filter(cls=>{
               if (state.scheduleFilter!=='today') return true;
-              const start = (cls.startAt?.toDate ? cls.startAt.toDate() : new Date(cls.startAt)).getTime();
-              return Date.now() <= start + 5*60*1000;
+              const start = cls.startAt?.toDate ? cls.startAt.toDate() : new Date(`${cls.classDate}T${cls.time}:00Z`);
+              return Date.now() <= start.getTime() + 5*60*1000;
             });
 
           const horarioHTML = filtered.length ? filtered.map(cls=>{
@@ -495,8 +498,9 @@
             let badge = `<span class="text-xs bg-emerald-500/50 text-emerald-300 px-2 py-1 rounded-md">¡Hay cupo!</span>`;
             if (isBooked) badge = `<span class="text-xs bg-indigo-500/50 text-indigo-300 px-2 py-1 rounded-md">Reservada</span>`;
             else if (available<=0) badge = `<span class="text-xs bg-rose-500/50 text-rose-300 px-2 py-1 rounded-md">Llena</span>`;
-            const ymd = cls.classDate || targetYMD;
-            const hhmm = cls.time || new Date(cls.startAt.toDate()).toLocaleTimeString('es-MX',{hour:'2-digit',minute:'2-digit',hour12:false});
+            const ymdUTC = cls.classDate || targetYMD;
+            const hhmmUTC = cls.time || cls.startAt.toDate().toISOString().slice(11,16);
+            const hhmm = timeFmt.format(new Date(`${ymdUTC}T${hhmmUTC}:00Z`));
             const safeName = DOMPurify.sanitize(cls.name || '');
             const safeInstructor = DOMPurify.sanitize(cls.instructor || '');
             const safeId = DOMPurify.sanitize(cls.id);
@@ -507,7 +511,7 @@
                   <p class="font-bold text-lg">${safeName}</p>
                   <p class="text-zinc-400 text-sm">con ${safeInstructor}</p>
                   <p class="text-sm mt-1 text-emerald-400">${hhmm} hrs</p>
-                  <p class="text-emerald-300 text-xs mt-0.5">${timeUntilLabel(ymd, hhmm)}</p>
+                  <p class="text-emerald-300 text-xs mt-0.5">${timeUntilLabel(ymdUTC, hhmmUTC)}</p>
                 </div>
                 <div class="text-right">${badge}</div>
               </div>`;
@@ -568,9 +572,9 @@
           const availableSpots = Number(cls.capacity||0)-enrolled;
           const isBooked = state.myBookings.some(b=>b.classId===cls.id);
           const durationMin = Number(cls.duration||60);
-          const ymd = cls.classDate || dateHelper.getYYYYMMDD(cls.startAt.toDate());
-          const hhmm = cls.time || new Date(cls.startAt.toDate()).toLocaleTimeString('es-MX',{hour:'2-digit',minute:'2-digit',hour12:false});
-          const timeRange = timeHelper.range(ymd, hhmm, durationMin);
+          const ymdUTC = cls.classDate || cls.startAt.toDate().toISOString().slice(0,10);
+          const hhmmUTC = cls.time || cls.startAt.toDate().toISOString().slice(11,16);
+          const timeRange = timeHelper.range(ymdUTC, hhmmUTC, durationMin);
           const safeName = DOMPurify.sanitize(cls.name || '');
           const safeDesc = DOMPurify.sanitize(cls.description || '');
           const safeId = DOMPurify.sanitize(cls.id);
@@ -657,7 +661,6 @@
                 const startAtTs = cls.startAt?.toDate ? cls.startAt : firebase.firestore.Timestamp.fromDate(new Date(cls.startAt));
                 const startDateObj = cls.startAt?.toDate ? cls.startAt.toDate() : new Date(cls.startAt);
                 const classDate = cls.classDate || dateHelper.getYYYYMMDD(startDateObj);
-                const timeFmt = new Intl.DateTimeFormat('es-MX',{hour:'2-digit',minute:'2-digit',hour12:false});
                 const time = cls.time || timeFmt.format(startDateObj);
                 tx.set(bookingRef, {
                   classId, userId: uid,


### PR DESCRIPTION
## Summary
- convert date/time helpers to use America/Mexico_City timezone
- format class times from UTC to local MX time in agenda and admin views
- save edited class times back to Firestore in UTC while displaying local time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba35fc30d08320aa4eddada6bc7201