### PR TITLE
chore: remove p-limit dependency

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -7,8 +7,7 @@
       "name": "functions",
       "dependencies": {
         "firebase-admin": "^12.0.0",
-        "firebase-functions": "^5.0.0",
-        "p-limit": "^3.1.0"
+        "firebase-functions": "^5.0.0"
       },
       "devDependencies": {
         "firebase-functions-test": "^3.1.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,8 +16,7 @@
   "main": "index.js",
   "dependencies": {
     "firebase-admin": "^12.0.0",
-    "firebase-functions": "^5.0.0",
-    "p-limit": "^3.1.0"
+    "firebase-functions": "^5.0.0"
   },
   "devDependencies": {
     "firebase-functions-test": "^3.1.0"


### PR DESCRIPTION
## Summary
- remove `p-limit` from Cloud Functions dependencies
- refresh lockfile

## Testing
- `npm test`
- `npm test` (functions) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba4cc5fe848320a32da2fcd336c7d2