### PR TITLE
Add waitlist rules and Firestore indexes

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,3 +1,7 @@
+// FILE: firebase.json
+// Firebase configuration for the Madness Schedule app.
+// Connects functions and Firestore settings used by the project.
+// RELEVANT FILES: firestore.rules, firestore.indexes.json, build-config.js
 {
   "functions": [
     {
@@ -13,6 +17,7 @@
     }
   ],
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   }
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,24 @@
+// FILE: firestore.indexes.json
+// Firestore index definitions for the Madness Schedule app.
+// Supports waitlist lookups by class and user.
+// RELEVANT FILES: firebase.json, firestore.rules, functions/index.js
+{
+  "indexes": [
+    {
+      "collectionGroup": "waitlists",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "classId", "order": "ASCENDING" },
+        { "fieldPath": "position", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "waitlists",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,3 +1,8 @@
+// FILE: firestore.rules
+// Firestore security rules for the Madness Schedule app.
+// Guards database access so only allowed users can read or write.
+// RELEVANT FILES: firebase.json, firestore.indexes.json, functions/index.js
+
 rules_version = '2';
 service cloud.firestore {
   match /databases/{db}/documents {
@@ -40,6 +45,16 @@ service cloud.firestore {
         && request.resource.data.startAt is timestamp
         && cooldownOk(request.auth.uid);
       allow update, delete: if (isSignedIn() && resource.data.userId == request.auth.uid) || isAdmin();
+    }
+
+    // ===== WAITLISTS =====
+    match /waitlists/{waitlistId} {
+      // classId (string), userId (string)
+      // position (number), joinedAt (timestamp)
+      // notifiedAt (timestamp | null), expiresAt (timestamp | null)
+      allow create: if isSignedIn() && request.auth.uid == request.resource.data.userId;
+      allow get, list: if (isSignedIn() && resource.data.userId == request.auth.uid) || isAdmin();
+      allow delete: if (isSignedIn() && resource.data.userId == request.auth.uid) || isAdmin();
     }
 
     // ===== USERS (Final, Simpler Ruleset) =====


### PR DESCRIPTION
## Summary
- add Firestore waitlist security rules for owners and admins
- configure Firestore indexes for waitlist queries
- reference indexes in Firebase config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4af2b7664832096991dc161e62875