### PR TITLE
feat: add facility capacity tracking

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -90,6 +90,12 @@
           <input type="date" id="att-start-date" class="bg-zinc-700 text-white p-1 rounded-md" />
           <label for="att-end-date">Hasta:</label>
           <input type="date" id="att-end-date" class="bg-zinc-700 text-white p-1 rounded-md" />
+          <label for="facility-capacity">Capacidad:</label>
+          <input type="number" id="facility-capacity" class="bg-zinc-700 text-white p-1 rounded-md w-20" min="1" />
+          <button id="att-export" class="bg-zinc-600 hover:bg-zinc-700 text-white font-bold py-1 px-2 rounded-md">Exportar</button>
+        </div>
+        <div class="w-full bg-zinc-700 h-2 rounded mb-4">
+          <div id="capacity-gauge-fill" class="h-2 bg-emerald-500 rounded" style="width:0%"></div>
         </div>
         <div class="relative">
           <canvas id="attendanceChart"></canvas>
@@ -175,6 +181,7 @@
         db: null,
         auth: null,
         functions: null,
+        FACILITY_MAX_CAPACITY: 75,
         state: {
           classes: [],
           bookingsMap: new Map(),
@@ -188,9 +195,8 @@
           unsubWaitlists: [],
           unsubRecentNotifs: null,
           attendanceData: null,
-          attendanceNextAt: 0,
           attendanceLastAt: 0,
-          attendancePollTimer: null,
+          unsubCapacity: null,
           attendanceTickTimer: null,
           userSearchResults: []
         },
@@ -260,11 +266,23 @@
           const range = this.getDefaultAttendanceRange();
           const sEl = document.getElementById('att-start-date');
           const eEl = document.getElementById('att-end-date');
+          const capEl = document.getElementById('facility-capacity');
+          const exportBtn = document.getElementById('att-export');
           if (sEl && eEl){
             sEl.value = range.start;
             eEl.value = range.end;
             sEl.addEventListener('change',()=>this.fetchAttendanceData(true));
             eEl.addEventListener('change',()=>this.fetchAttendanceData(true));
+          }
+          if (capEl){
+            capEl.value = this.FACILITY_MAX_CAPACITY;
+            capEl.addEventListener('change',()=>{
+              this.FACILITY_MAX_CAPACITY = Number(capEl.value)||0;
+              this.fetchAttendanceData(true);
+            });
+          }
+          if (exportBtn){
+            exportBtn.onclick = () => this.exportCapacityReport();
           }
 
           // Users: find + list
@@ -641,17 +659,18 @@
         startAttendancePolling(){
           this.fetchAttendanceData(true);
           this.stopAttendancePolling();
-          this.state.attendancePollTimer = setInterval(()=>{ this.fetchAttendanceData(true); }, 15*60*1000);
+          this.state.unsubCapacity = this.db.collection('bookings').onSnapshot(()=>{
+            this.fetchAttendanceData(true);
+          });
           this.state.attendanceTickTimer = setInterval(()=>{ this.updateAttendanceLegend(); }, 1000);
         },
         stopAttendancePolling(){
-          if (this.state.attendancePollTimer){ clearInterval(this.state.attendancePollTimer); this.state.attendancePollTimer=null; }
+          if (this.state.unsubCapacity){ this.state.unsubCapacity(); this.state.unsubCapacity=null; }
           if (this.state.attendanceTickTimer){ clearInterval(this.state.attendanceTickTimer); this.state.attendanceTickTimer=null; }
         },
 
-        async fetchAttendanceData(force=false){
+        async fetchAttendanceData(){
           const now = Date.now();
-          if (!force && this.state.attendanceNextAt && now < this.state.attendanceNextAt) return;
           const { start, end } = this.getSelectedAttendanceRange();
           const report = {};
           const labels = [];
@@ -659,8 +678,7 @@
           const endDate = new Date(end);
           for (let dt = new Date(startDate); dt <= endDate; dt.setDate(dt.getDate()+1)){
             const d = this.dateHelper.ymd(dt);
-            // initializer (merged)
-            report[d] = { attended:0, absent:0, booked:0, details:{ attended:{}, absent:{}, booked:{} } };
+            report[d] = { attended:0, absent:0, booked:0, totalCapacity:0, utilizationRate:0, warning:'', details:{ attended:{}, absent:{}, booked:{} } };
             labels.push({ date:d, label:this.dayShortFmt.format(new Date(dt)) });
           }
           try {
@@ -678,45 +696,39 @@
               report[r.classDate].details[cat][key].push(r.userName);
             });
 
-            // compute booked for today/tomorrow (merged)
-            const todayStr = this.dateHelper.today();
-            const tomorrowStr = this.dateHelper.tomorrow();
-
-            if (report[todayStr]){
-              let booked = 0; const det = {};
-              this.state.classes.filter(c=>c.classDate===todayStr).forEach(c=>{
-                const arr = this.state.bookingsMap.get(c.id)||[];
-                if (arr.length){
-                  booked += arr.length;
-                  const label = `${c.time} - ${c.name}`;
-                  det[label] = arr.map(x=>x.userName||'Anónimo');
-                }
-              });
-              report[todayStr].booked = booked;
-              report[todayStr].details.booked = det;
-            }
-
-            if (report[tomorrowStr]){
-              let booked = 0; const det = {};
-              this.state.classes.filter(c=>c.classDate===tomorrowStr).forEach(c=>{
-                const arr = this.state.bookingsMap.get(c.id)||[];
-                if (arr.length){
-                  booked += arr.length;
-                  const label = `${c.time} - ${c.name}`;
-                  det[label] = arr.map(x=>x.userName||'Anónimo');
-                }
-              });
-              report[tomorrowStr].booked = booked;
-              report[tomorrowStr].details.booked = det;
-            }
+            const dayStats = {};
+            this.state.classes.forEach(c=>{
+              const day = c.classDate;
+              if (!report[day]) return;
+              const arr = this.state.bookingsMap.get(c.id)||[];
+              const cap = Number(c.capacity||0);
+              if (!dayStats[day]) dayStats[day] = { booked:0, capacity:0, details:{} };
+              dayStats[day].booked += arr.length;
+              dayStats[day].capacity += cap;
+              if (arr.length){
+                const label = `${c.time} - ${c.name}`;
+                dayStats[day].details[label] = arr.map(x=>x.userName||'Anónimo');
+              }
+            });
+            Object.entries(dayStats).forEach(([day,st])=>{
+              const r = report[day];
+              r.booked = st.booked;
+              r.details.booked = st.details;
+              r.totalCapacity = st.capacity;
+              r.utilizationRate = Math.round((st.booked/this.FACILITY_MAX_CAPACITY)*100);
+              if (r.utilizationRate>85) r.warning='Capacidad crítica';
+              else if (r.utilizationRate>60) r.warning='Capacidad alta';
+              else r.warning='Capacidad estable';
+            });
 
             this.state.attendanceData = { report, labels };
             this.state.attendanceLastAt = now;
-            this.state.attendanceNextAt = now + 15*60*1000;
-            this.updateAttendanceLegend();
-            this.renderAttendanceChartFromCache();
-          } catch(e){ console.error('Error leyendo asistencia:', e); }
-        },
+          this.updateAttendanceLegend();
+          this.renderAttendanceChartFromCache();
+          this.updateCapacityGauge();
+          console.log('Proyecciones:', this.calculateCapacityProjections());
+        } catch(e){ console.error('Error leyendo asistencia:', e); }
+      },
 
         updateAttendanceLegend(){
           const lastEl = document.getElementById('att-last');
@@ -726,13 +738,44 @@
             const fmt = new Intl.DateTimeFormat('es-MX',{hour:'2-digit',minute:'2-digit'});
             lastEl.textContent = `Última actualización: ${fmt.format(new Date(this.state.attendanceLastAt))}`;
           } else lastEl.textContent = 'Última actualización: —';
+          nextEl.textContent = 'Actualización en vivo';
+        },
 
-          if (this.state.attendanceNextAt){
-            const ms = Math.max(0, this.state.attendanceNextAt - Date.now());
-            const mm = Math.floor(ms/60000);
-            const ss = Math.floor((ms%60000)/1000);
-            nextEl.textContent = `Próxima actualización en: ${mm}m ${String(ss).padStart(2,'0')}s`;
-          } else nextEl.textContent = 'Próxima actualización en: —';
+        updateCapacityGauge(){
+          const fill = document.getElementById('capacity-gauge-fill');
+          if (!fill || !this.state.attendanceData) return;
+          const today = this.dateHelper.today();
+          const d = this.state.attendanceData.report[today];
+          if (!d){ fill.style.width = '0%'; return; }
+          const rate = d.utilizationRate || 0;
+          fill.style.width = Math.min(rate,100)+'%';
+          fill.classList.remove('bg-emerald-500','bg-amber-500','bg-rose-500');
+          if (rate>85) fill.classList.add('bg-rose-500');
+          else if (rate>60) fill.classList.add('bg-amber-500');
+          else fill.classList.add('bg-emerald-500');
+        },
+
+        calculateCapacityProjections(){
+          const rep = this.state.attendanceData?.report || {};
+          const arr = Object.values(rep);
+          const avg = arr.reduce((s,d)=>s+(d.utilizationRate||0),0)/(arr.length||1);
+          const suggestion = avg>85?'Añadir más clases': avg>60?'Monitorear capacidad':'Capacidad adecuada';
+          return { averageUtilization: Math.round(avg), suggestion };
+        },
+
+        exportCapacityReport(){
+          const data = this.state.attendanceData;
+          if (!data) return;
+          const rows = [['Fecha','Asistieron','Faltaron','Reservaron','Capacidad','Utilización %']];
+          Object.entries(data.report).forEach(([date,d])=>{
+            rows.push([date,d.attended,d.absent,d.booked,d.totalCapacity,d.utilizationRate]);
+          });
+          const csv = rows.map(r=>r.join(',')).join('\n');
+          const blob = new Blob([csv],{type:'text/csv'});
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url; a.download = 'capacity-report.csv'; a.click();
+          URL.revokeObjectURL(url);
         },
 
         renderAttendanceChartFromCache(){
@@ -749,6 +792,9 @@
           const attendedData = labels.map(l=>report[l.date].attended||0);
           const absentData   = labels.map(l=>report[l.date].absent||0);
           const bookedData   = labels.map(l=>report[l.date].booked||0);
+          const utilData     = labels.map(l=>report[l.date].utilizationRate||0);
+          const utilColors   = utilData.map(u=>u>85?'rgba(248,113,113,1)':u>60?'rgba(251,191,36,1)':'rgba(52,211,153,1)');
+          const capLine      = labels.map(()=>this.FACILITY_MAX_CAPACITY);
 
           const includeBooked = bookedData.some(v => v > 0);
           const datasets = [
@@ -758,6 +804,8 @@
           if (includeBooked){
             datasets.push({ label:'Reservaron', data:bookedData, backgroundColor:'rgba(59,130,246,.6)' });
           }
+          datasets.push({ label:'Utilización %', data:utilData, type:'line', yAxisID:'y1', borderColor:'#818cf8', pointBackgroundColor:utilColors, fill:false, tension:0.1 });
+          datasets.push({ label:`Capacidad ${this.FACILITY_MAX_CAPACITY}`, data:capLine, type:'line', borderColor:'#fcd34d', borderDash:[5,5], pointRadius:0 });
 
           if (this.state.attendanceChartInstance) this.state.attendanceChartInstance.destroy();
           this.state.attendanceChartInstance = new Chart(ctx,{
@@ -765,7 +813,8 @@
             data:{ labels: lbls, datasets },
             options:{
               scales:{
-                y:{ beginAtZero:true, ticks:{ color:'#a1a1aa', stepSize:1 }, grid:{ color:'#3f3f46' } },
+                y:{ beginAtZero:true, ticks:{ color:'#a1a1aa', stepSize:1 }, grid:{ color:'#3f3f46' }, suggestedMax:this.FACILITY_MAX_CAPACITY },
+                y1:{ beginAtZero:true, position:'right', ticks:{ color:'#a1a1aa', callback:v=>v+'%' }, grid:{ drawOnChartArea:false } },
                 x:{ ticks:{ color:'#a1a1aa', autoSkip:true, maxRotation:45 }, grid:{ color:'#3f3f46' } }
               },
               plugins:{ legend:{ labels:{ color:'#d4d4d8' } } }
@@ -784,24 +833,29 @@
             `;}).join('');
           };
 
-          const todayStr = this.dateHelper.today();
-          const tomorrowStr = this.dateHelper.tomorrow();
-
           details.innerHTML = labels.map(l=>{
             const d = report[l.date];
-            // Card header
             let html = `
               <div class="bg-zinc-900 p-3 rounded-md">
                 <h4 class="font-bold text-lg mb-2">${DOMPurify.sanitize(l.label)}</h4>`;
 
-            // Show booked for today/tomorrow if present
-            if (d.booked && (l.date === todayStr || l.date === tomorrowStr)) {
+            if (d.booked){
               html += `
                 <div class="font-semibold text-blue-400">Reservaron (${d.booked||0})</div>
                 ${renderList(d.details.booked)}`;
             }
 
+            const warnColor = d.utilizationRate>85?'text-rose-400': d.utilizationRate>60?'text-amber-400':'text-emerald-400';
+            const peak = Object.entries(d.details.booked||{}).map(([k,v])=>({k,v:v.length})).reduce((a,b)=> b.v>(a?.v||0)?b:a,null);
+            const peakLabel = peak?peak.k:'—';
+            const revenue = d.booked*100;
+
             html += `
+                <div class="text-sm mt-2">Capacidad total: ${d.totalCapacity||0}</div>
+                <div class="text-sm">Utilización: ${d.utilizationRate||0}%</div>
+                <div class="${warnColor} text-sm">${DOMPurify.sanitize(d.warning||'')}</div>
+                <div class="text-sm mt-1">Hora pico: ${DOMPurify.sanitize(peakLabel)}</div>
+                <div class="text-sm">Ingresos estimados: $${revenue}</div>
                 <div class="font-semibold text-emerald-400 mt-2">Asistieron (${d.attended||0})</div>
                 ${renderList(d.details.attended)}
                 <div class="font-semibold text-rose-400 mt-2">Faltaron (${d.absent||0})</div>


### PR DESCRIPTION
## Summary
- track facility capacity with configurable limit and utilization metrics
- display capacity usage in charts, details, and real-time gauge
- export capacity reports and basic utilization projections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4bcc03bd48320bd957b3e42b4ef16