### PR TITLE
Show booking names in attendance report

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -674,8 +674,9 @@
           const { start, end } = this.getSelectedAttendanceRange();
           const report = {};
           const labels = [];
-          const startDate = new Date(start);
-          const endDate = new Date(end);
+          // Parse selected range in Mexico City time to avoid UTC date shifts
+          const startDate = new Date(`${start}T00:00:00-06:00`);
+          const endDate = new Date(`${end}T00:00:00-06:00`);
           for (let dt = new Date(startDate); dt <= endDate; dt.setDate(dt.getDate()+1)){
             const d = this.dateHelper.ymd(dt);
             report[d] = { attended:0, absent:0, booked:0, totalCapacity:0, utilizationRate:0, warning:'', details:{ attended:{}, absent:{}, booked:{} } };
@@ -698,7 +699,8 @@
 
             const dayStats = {};
             this.state.classes.forEach(c=>{
-              const day = c.classDate;
+              // Use local date so bookings align with America/Mexico_City
+              const day = c.localDate || c.classDate;
               if (!report[day]) return;
               const arr = this.state.bookingsMap.get(c.id)||[];
               const cap = Number(c.capacity||0);
@@ -763,6 +765,27 @@
           return { averageUtilization: Math.round(avg), suggestion };
         },
 
+        // Update report with current bookings before rendering
+        injectBookingsIntoReport(){
+          const data = this.state.attendanceData;
+          if (!data) return;
+          const { report } = data;
+          Object.keys(report).forEach(day=>{
+            const classes = this.state.classes.filter(c=>c.localDate===day);
+            let total = 0;
+            const details = {};
+            classes.forEach(cls=>{
+              const arr = (this.state.bookingsMap.get(cls.id)||[]).map(b=>b.userName||'Anónimo');
+              if (arr.length){
+                details[`${cls.time} - ${cls.name}`] = arr;
+                total += arr.length;
+              }
+            });
+            report[day].booked = total;
+            report[day].details.booked = details;
+          });
+        },
+
         exportCapacityReport(){
           const data = this.state.attendanceData;
           if (!data) return;
@@ -787,6 +810,7 @@
             details.innerHTML = `<div class="bg-zinc-900 p-3 rounded-md text-zinc-400">Cargando reporte… se actualizará automáticamente.</div>`;
             return;
           }
+          this.injectBookingsIntoReport();
           const { report, labels } = dataCache;
           const lbls = labels.map(l=>l.label);
           const attendedData = labels.map(l=>report[l.date].attended||0);


### PR DESCRIPTION
## Summary
- parse attendance report date range in America/Mexico_City time to avoid UTC shift
- align booking stats with local dates so names for today and tomorrow are accurate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c022436c832096547d2e0e15ea0c