### PR TITLE
feat: add guest counter to classes

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -156,6 +156,8 @@
             <input type="text" id="class-icon" placeholder="Emoji Ícono (🧘‍♀️)" class="w-full bg-zinc-700 p-2 rounded">
           </div>
           <textarea id="class-description" placeholder="Descripción" class="w-full bg-zinc-700 p-2 rounded h-24 mt-4"></textarea>
+          <input type="number" id="class-guest-spots" placeholder="Spots para invitados"
+                 class="w-full bg-zinc-700 p-2 rounded mt-4" min="0" value="0">
         </div>
         <div id="attendance-content" class="hidden">
           <div id="attendance-status-message" class="text-center text-zinc-400 p-4"></div>
@@ -567,6 +569,8 @@
             const isRunning = this.isClassRunningNow(cls);
             const style = isRunning ? 'bg-emerald-900 border border-emerald-600' : 'bg-zinc-800';
             const enrolled = Number(cls.enrolledCount||0);
+            const guestSpots = Number(cls.guestSpots||0);
+            const totalUsed = enrolled + guestSpots;
             const capacity = Number(cls.capacity||0);
             const card = document.createElement('div');
             card.className = `p-4 rounded-lg shadow-md cursor-pointer hover:bg-zinc-700 transition-colors ${style}`;
@@ -587,7 +591,7 @@
               </div>
               <div class="mt-4 flex justify-between items-center text-sm">
                 <span class="font-semibold">a las ${safeTime}</span>
-                <span class="font-bold ${enrolled>=capacity?'text-rose-400':'text-white'}">${enrolled} / ${capacity}</span>
+                <span class="font-bold ${totalUsed>=capacity?'text-rose-400':'text-white'}">${enrolled}+${guestSpots} / ${capacity}</span>
               </div>`;
             if (cls.localDate === this.dateHelper.today()) todayC.appendChild(card);
             else if (cls.localDate === this.dateHelper.tomorrow()) tomorrowC.appendChild(card);
@@ -908,6 +912,7 @@
           document.getElementById('class-time').value = cls.localTime || cls.time || '';
           document.getElementById('class-icon').value = cls.icon || '';
           document.getElementById('class-description').value = cls.description || '';
+          document.getElementById('class-guest-spots').value = cls.guestSpots || 0;
 
           const tabD = document.getElementById('tab-details');
           const tabA = document.getElementById('tab-attendance');
@@ -1301,6 +1306,7 @@
             time: document.getElementById('class-time').value,
             icon: document.getElementById('class-icon').value,
             description: document.getElementById('class-description').value,
+            guestSpots: Number(document.getElementById('class-guest-spots').value) || 0,
           };
           try{
             const cls = this.state.classes.find(c=>c.id===id);

--- a/index.html
+++ b/index.html
@@ -505,7 +505,8 @@
 
           const horarioHTML = filtered.length ? filtered.map(cls=>{
             const enrolled = Number(cls.enrolledCount||0);
-            const available = Number(cls.capacity||0)-enrolled;
+            const guestSpots = Number(cls.guestSpots||0);
+            const available = Number(cls.capacity||0)-enrolled-guestSpots;
             const isBooked = state.myBookings.some(b=>b.classId===cls.id);
             const waitEntry = state.waitlistEntries.find(w=>w.classId===cls.id); // check if user already in waitlist
             const notified = waitEntry && waitEntry.notifiedAt && (!waitEntry.expiresAt || asDate(waitEntry.expiresAt).getTime()>Date.now()); // notified users can book even if class shows full
@@ -595,7 +596,8 @@
             const cls = state.classes.find(c=>c.id===classId);
             if (!cls) return getAgendaScreenHTML();
             const enrolled = Number(cls.enrolledCount||0);
-            const availableSpots = Number(cls.capacity||0)-enrolled;
+            const guestSpots = Number(cls.guestSpots||0);
+            const availableSpots = Number(cls.capacity||0)-enrolled-guestSpots;
             const isBooked = state.myBookings.some(b=>b.classId===cls.id);
             const waitEntry = state.waitlistEntries.find(w=>w.classId===cls.id); // user's waitlist entry if any
             const notified = waitEntry && waitEntry.notifiedAt && (!waitEntry.expiresAt || asDate(waitEntry.expiresAt).getTime()>Date.now()); // true if user has active waitlist notification
@@ -698,8 +700,10 @@
                 }
                 const cls = classSnap.data();
                 const enrolled = Number(cls.enrolledCount||0);
+                const guestSpots = Number(cls.guestSpots||0);
                 const capacity = Number(cls.capacity||0);
-                if (enrolled>=capacity && !notified) throw new Error('Clase llena.');
+                const availableForUsers = capacity - enrolled - guestSpots;
+                if (availableForUsers <= 0 && !notified) throw new Error('Clase llena.');
                 const startAtTs = cls.startAt?.toDate ? cls.startAt : firebase.firestore.Timestamp.fromDate(new Date(cls.startAt));
                 const startDateObj = cls.startAt?.toDate ? cls.startAt.toDate() : new Date(cls.startAt);
                 const classDate = cls.classDate || dateHelper.getYYYYMMDD(startDateObj);


### PR DESCRIPTION
## Summary
- allow admins to track walk-in guests per class
- account for guest spots when displaying capacity and booking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7b24cb05483208ae95d42c6d26ffc