### PR TITLE
Allow first enrollment count update

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -28,12 +28,23 @@ service cloud.firestore {
       allow read: if true;
       allow create, update, delete: if isAdmin();
 
+      // Members can nudge the enrollment count by one.
+      // First booking initializes the count when it is missing.
       allow update: if isAdmin() || (
         isSignedIn()
         && request.resource.data.diff(resource.data).changedKeys().hasOnly(['enrolledCount'])
         && (
-          request.resource.data.enrolledCount == resource.data.enrolledCount + 1 ||
-          request.resource.data.enrolledCount == resource.data.enrolledCount - 1
+          (
+            resource.data.enrolledCount == null
+            && request.resource.data.enrolledCount == 1
+          )
+          || (
+            resource.data.enrolledCount != null
+            && (
+              request.resource.data.enrolledCount == resource.data.enrolledCount + 1 ||
+              request.resource.data.enrolledCount == resource.data.enrolledCount - 1
+            )
+          )
         )
       );
     }


### PR DESCRIPTION
## Summary
- allow members to initialize enrolledCount to 1 when the field is missing
- keep +/-1 adjustments for subsequent enrollment changes

## Testing
- firebase deploy --only firestore:rules *(fails: firebase CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c95a5d40f88320a7e718c2f5570816