### PR TITLE
Allow waitlist get when doc missing

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -91,7 +91,11 @@ service cloud.firestore {
     // ===== WAITLISTS =====
     match /waitlists/{waitlistId} {
       allow create: if isSignedIn() && request.auth.uid == request.resource.data.userId;
-      allow get, list: if (isSignedIn() && resource.data.userId == request.auth.uid) || isAdmin();
+
+      // Transactions read missing docs before writes, so allow the null resource case.
+      allow get: if isAdmin() || (isSignedIn() && (resource == null || resource.data.userId == request.auth.uid));
+
+      allow list: if (isSignedIn() && resource.data.userId == request.auth.uid) || isAdmin();
       allow delete: if (isSignedIn() && resource.data.userId == request.auth.uid) || isAdmin();
     }
     


### PR DESCRIPTION
## Summary
- allow signed-in users to get waitlist docs when the entry is missing so transactions can run

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c95f51b9988320b43a546ddc87fcea