### PR TITLE
Fix enrollment count updates for member bookings

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -32,17 +32,19 @@ service cloud.firestore {
       // First booking initializes the count when it is missing.
       allow update: if isAdmin() || (
         isSignedIn()
-        && request.resource.data.diff(resource.data).changedKeys().hasOnly(['enrolledCount'])
+        && let before = resource.data;
+        && let after = getAfter(/databases/$(db)/documents/classes/$(classId)).data;
+        && after.diff(before).changedKeys().hasOnly(['enrolledCount'])
         && (
           (
-            resource.data.enrolledCount == null
-            && request.resource.data.enrolledCount == 1
+            before.enrolledCount == null
+            && after.enrolledCount == 1
           )
           || (
-            resource.data.enrolledCount != null
+            before.enrolledCount != null
             && (
-              request.resource.data.enrolledCount == resource.data.enrolledCount + 1 ||
-              request.resource.data.enrolledCount == resource.data.enrolledCount - 1
+              after.enrolledCount == before.enrolledCount + 1 ||
+              after.enrolledCount == before.enrolledCount - 1
             )
           )
         )


### PR DESCRIPTION
## Summary
- switch the class enrollment rule to use `getAfter` so FieldValue transforms are evaluated after the write
- keep the increment/decrement guardrails while allowing members to adjust `enrolledCount`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9615724a4832098824efe33442f08