### PR TITLE
Fix cooldown timestamp warning in Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -20,12 +20,15 @@ service cloud.firestore {
     
     function cooldownOk(uid) {
       let userDoc = get(/databases/$(db)/documents/users/$(uid));
-      let cancel = userDoc == null ? null : userDoc.data.lastCancelAt;
-      return cancel == null
-        || (
-          cancel is timestamp
-          && request.time.toMillis() - cancel.toMillis() >= 15 * 60 * 1000
-        );
+
+      // Store the millisecond timestamp only when the last cancel is valid.
+      let cancelMillis = userDoc != null
+        && userDoc.data.lastCancelAt is timestamp
+        ? userDoc.data.lastCancelAt.toMillis()
+        : null;
+
+      return cancelMillis == null
+        || request.time.toMillis() - cancelMillis >= 15 * 60 * 1000;
     }
 
     // ===== CLASSES (Refined) =====


### PR DESCRIPTION
## Summary
- guard the cooldown helper by storing a millisecond value only when lastCancelAt is a valid timestamp
- keep the null path simple to avoid Firestore rule compilation warnings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99ff61c9c8320a323fa76620bec5f