### PR TITLE
Fix cooldown guard to avoid null millis

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -21,14 +21,12 @@ service cloud.firestore {
     function cooldownOk(uid) {
       let userDoc = get(/databases/$(db)/documents/users/$(uid));
 
-      // Store the millisecond timestamp only when the last cancel is valid.
-      let cancelMillis = userDoc != null
-        && userDoc.data.lastCancelAt is timestamp
-        ? userDoc.data.lastCancelAt.toMillis()
-        : null;
+      // Only enforce the cooldown when we find a timestamp on the user record.
+      let hasLastCancel = userDoc != null && userDoc.data.lastCancelAt is timestamp;
 
-      return cancelMillis == null
-        || request.time.toMillis() - cancelMillis >= 15 * 60 * 1000;
+      return hasLastCancel
+        ? request.time.toMillis() - userDoc.data.lastCancelAt.toMillis() >= 15 * 60 * 1000
+        : true;
     }
 
     // ===== CLASSES (Refined) =====


### PR DESCRIPTION
## Summary
- guard the cooldown helper against null timestamp reads from the user profile
- ensure the cooldown only applies when the last cancel timestamp exists

## Testing
- not run (rules change only)


------
https://chatgpt.com/codex/tasks/task_e_68c9a0df1dc08320834d89ee78a7ce0e