### PR TITLE
Add notification for generated daily classes

### DIFF
--- a/functions/src/generateDailyClasses.js
+++ b/functions/src/generateDailyClasses.js
@@ -124,7 +124,12 @@ exports.generateDailyClasses = onSchedule(
         });
 
         existingTimes.add(timeUTC);
-        created.push({ date: classDate, time: timeFormatter.format(startAt.toDate()), name: entry?.name });
+        created.push({
+          id: docRef.id,
+          date: classDate,
+          time: timeFormatter.format(startAt.toDate()),
+          name: entry?.name,
+        });
       }
     }
 
@@ -138,6 +143,18 @@ exports.generateDailyClasses = onSchedule(
       `[generateDailyClasses] Created ${created.length} classes:`,
       created
     );
+
+    const notificationRecord = {
+      type: "daily-classes",
+      classId: "Generación automática",
+      userId: `Se generaron ${created.length} clases`,
+      sentAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdCount: created.length,
+      classes: created,
+    };
+
+    // Store a summary notification so the admin dashboard highlights the run.
+    await db.collection("notifications").add(notificationRecord);
 
     return { created: created.length, classes: created };
   }


### PR DESCRIPTION
## Summary
- capture generated class document ids when building the daily schedule
- record a summary notification after creating classes so admins see the run in Últimas notificaciones

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb07200e2c832095f6844fee4eba71