### PR TITLE
Enhance notification logging with FCM delivery metadata

### DIFF
--- a/functions/src/totalPassReminders.js
+++ b/functions/src/totalPassReminders.js
@@ -179,6 +179,7 @@ exports.sendTotalPassReminder = onTaskDispatched(
     }
 
     const prunePromises = [];
+    const failedTokens = [];
     responseAggregate.responses.forEach((res, idx) => {
       if (!res.success) {
         const token = tokens[idx];
@@ -191,6 +192,7 @@ exports.sendTotalPassReminder = onTaskDispatched(
         } else {
           console.error('TotalPass notification failure', token, classId, code);
         }
+        failedTokens.push({ token, errorCode: code || 'unknown' });
       }
     });
 
@@ -207,6 +209,10 @@ exports.sendTotalPassReminder = onTaskDispatched(
       userId,
       type: 'totalpass',
       sentAt: admin.firestore.FieldValue.serverTimestamp(),
+      tokensUsed: [...tokens],
+      successCount: responseAggregate.successCount,
+      failureCount: responseAggregate.failureCount,
+      failedTokens,
     };
     if (className) {
       notificationRecord.className = className;


### PR DESCRIPTION
## Summary
- capture FCM delivery metadata for booking reminders and persist it alongside existing notification fields
- log waitlist notifications to the notifications collection with token usage, success/failure counts, and failure details
- extend TotalPass reminder records with the same delivery metrics for consistent admin visibility

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cba4c42c108320b85159e5bd8c3217