### PR TITLE
Fix attendance editing accidentally modifying class times

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -155,6 +155,7 @@
             <input type="text" id="class-time" placeholder="Hora (ej. 18:00)" class="w-full bg-zinc-700 p-2 rounded">
             <input type="text" id="class-icon" placeholder="Emoji Ícono (🧘‍♀️)" class="w-full bg-zinc-700 p-2 rounded">
           </div>
+          <p id="class-time-warning" class="mt-2 text-xs text-amber-400 hidden"></p>
           <textarea id="class-description" placeholder="Descripción" class="w-full bg-zinc-700 p-2 rounded h-24 mt-4"></textarea>
         </div>
         <div id="attendance-content" class="hidden">
@@ -189,6 +190,7 @@
           weeklySchedule: {},
           recentNotifications: [],
           currentAttendance: {},
+          selectedClass: null,
           attendanceChartInstance: null,
           unsubClasses: null,
           unsubBookings: [],
@@ -961,8 +963,9 @@
           return (start>=lower) && (start<=upper);
         },
 
-        showClassModal(cls){
+        async showClassModal(cls){
           this.state.currentAttendance = {};
+          this.state.selectedClass = cls ? { ...cls } : null;
           document.getElementById('class-id').value = cls.id;
           document.getElementById('class-name').value = cls.name || '';
           document.getElementById('class-instructor').value = cls.instructor || '';
@@ -990,27 +993,81 @@
           };
           document.getElementById('cancel-button').onclick = () => this.hideClassModal();
           document.getElementById('save-button').onclick = () => this.saveClass();
-
           const modal = document.getElementById('class-modal');
-          modal.classList.remove('hidden');
-          document.getElementById('save-button').focus();
+          const saveBtnEl = document.getElementById('save-button');
+          const timeEl = document.getElementById('class-time');
+          if (timeEl){
+            timeEl.readOnly = true;
+            timeEl.classList.add('cursor-not-allowed','opacity-60');
+          }
+          if (modal) modal.classList.remove('hidden');
+          saveBtnEl?.focus();
+          await this.refreshClassTimeLock(cls);
         },
 
-        hideClassModal(){ document.getElementById('class-modal').classList.add('hidden'); },
+        hideClassModal(){
+          document.getElementById('class-modal').classList.add('hidden');
+          this.state.selectedClass = null;
+        },
+
+        async refreshClassTimeLock(cls){
+          const timeInput = document.getElementById('class-time');
+          const warning = document.getElementById('class-time-warning');
+          if (!timeInput) return;
+
+          timeInput.readOnly = false;
+          timeInput.classList.remove('cursor-not-allowed','opacity-60');
+          timeInput.removeAttribute('aria-readonly');
+          if (warning){
+            warning.textContent = '';
+            warning.classList.add('hidden');
+          }
+
+          if (!cls?.id){
+            return;
+          }
+
+          try{
+            const snap = await this.db.collection('attendance').where('classId','==',cls.id).limit(1).get();
+            const hasAttendance = !snap.empty;
+            if (hasAttendance){
+              timeInput.value = cls.localTime || cls.time || '';
+              timeInput.readOnly = true;
+              timeInput.classList.add('cursor-not-allowed','opacity-60');
+              timeInput.setAttribute('aria-readonly','true');
+              if (warning){
+                warning.textContent = 'Esta clase tiene asistencia registrada. La hora no se puede modificar.';
+                warning.classList.remove('hidden');
+              }
+            }
+          }catch(err){
+            console.error('No se pudo verificar asistencia', err);
+            timeInput.readOnly = true;
+            timeInput.classList.add('cursor-not-allowed','opacity-60');
+            timeInput.setAttribute('aria-readonly','true');
+            if (warning){
+              warning.textContent = 'No pudimos verificar la asistencia. Evita cambiar la hora.';
+              warning.classList.remove('hidden');
+            }
+          }
+        },
 
         switchTab(tab){
           const tabD = document.getElementById('tab-details');
           const tabA = document.getElementById('tab-attendance');
           const contD = document.getElementById('details-content');
           const contA = document.getElementById('attendance-content');
+          const saveBtn = document.getElementById('save-button');
           if (tab==='details'){
             tabD.classList.add('border-b-2','border-indigo-500','text-indigo-400'); tabD.setAttribute('aria-selected','true');
             tabA.classList.remove('border-b-2','border-indigo-500','text-indigo-400'); tabA.setAttribute('aria-selected','false');
             contD.classList.remove('hidden'); contA.classList.add('hidden');
+            if (saveBtn) saveBtn.classList.remove('hidden');
           } else {
             tabA.classList.add('border-b-2','border-indigo-500','text-indigo-400'); tabA.setAttribute('aria-selected','true');
             tabD.classList.remove('border-b-2','border-indigo-500','text-indigo-400'); tabD.setAttribute('aria-selected','false');
             contA.classList.remove('hidden'); contD.classList.add('hidden');
+            if (saveBtn) saveBtn.classList.add('hidden');
           }
         },
 
@@ -1064,21 +1121,32 @@
             parent.querySelectorAll('.attendance-btn').forEach(x=>x.classList.remove('selected-attended','selected-absent'));
             btn.classList.add(status==='attended'?'selected-attended':'selected-absent');
           };
-          save.onclick = () => this.saveAttendance(cls);
+          save.onclick = () => this.saveAttendance();
         },
 
-        async saveAttendance(cls){
+        async saveAttendance(){
+          const clsId = document.getElementById('class-id')?.value;
+          const cls = this.state.selectedClass || this.state.classes.find(c=>c.id===clsId);
+          if (!cls){
+            this.showToast({ title:'Clase no disponible', message:'No pudimos cargar la clase para guardar asistencia.', variant:'error' });
+            return;
+          }
           const data = this.state.currentAttendance;
           if (!Object.keys(data).length){
             this.showToast({ title:'Sin cambios', message:'No marcaste asistencia', variant:'warn' });
             return;
           }
           const batch = this.db.batch();
+          const classDate = cls.classDate || cls.localDate || '';
+          if (!classDate){
+            this.showToast({ title:'Clase sin fecha', message:'No se pudo identificar la fecha de la clase.', variant:'error' });
+            return;
+          }
           Object.keys(data).forEach(uid=>{
             const rec = data[uid];
-            const ref = this.db.collection('attendance').doc(`${cls.classDate}_${cls.id}_${uid}`);
+            const ref = this.db.collection('attendance').doc(`${classDate}_${cls.id}_${uid}`);
             batch.set(ref,{
-              classId: cls.id, className: cls.name, classDate: cls.classDate,
+              classId: cls.id, className: cls.name, classDate,
               userId: uid, userName: rec.userName, status: rec.status, recordedAt: new Date()
             },{ merge:true });
           });
@@ -1401,23 +1469,52 @@
         // ---- CRUD Clase ----
         async saveClass(){
           const id = document.getElementById('class-id').value; if(!id) return;
-          const data = {
-            name: document.getElementById('class-name').value,
-            instructor: document.getElementById('class-instructor').value,
-            time: document.getElementById('class-time').value,
-            icon: document.getElementById('class-icon').value,
-            description: document.getElementById('class-description').value,
-          };
+          const name = document.getElementById('class-name').value.trim();
+          const instructor = document.getElementById('class-instructor').value.trim();
+          const icon = document.getElementById('class-icon').value.trim();
+          const description = document.getElementById('class-description').value.trim();
+          const timeInputEl = document.getElementById('class-time');
+          const timeInputValue = (timeInputEl?.value || '').trim();
+          const data = { name, instructor, icon, description };
+
           try{
             const cls = this.state.classes.find(c=>c.id===id);
-            if (cls && data.time && data.time !== (cls.localTime || cls.time)){
-              const start = new Date(`${cls.localDate||cls.classDate}T${data.time}:00-06:00`);
+            if (!cls){
+              this.showToast({ title:'Clase no encontrada', message:'No pudimos ubicar la clase seleccionada.', variant:'error' });
+              return;
+            }
+
+            const originalTime = cls.localTime || cls.time || '';
+            const wantsTimeChange = timeInputValue && timeInputValue !== originalTime;
+            let canApplyTimeChange = wantsTimeChange;
+
+            if (wantsTimeChange){
+              try{
+                const attSnap = await this.db.collection('attendance').where('classId','==',id).limit(1).get();
+                if (!attSnap.empty){
+                  canApplyTimeChange = false;
+                  if (timeInputEl) timeInputEl.value = originalTime;
+                  await this.refreshClassTimeLock(cls);
+                  this.showToast({ title:'Hora bloqueada', message:'Esta clase ya tiene asistencia registrada. No puedes cambiar la hora.', variant:'warn' });
+                }
+              }catch(err){
+                console.error('Error validando asistencia antes de cambiar hora', err);
+                canApplyTimeChange = false;
+                if (timeInputEl) timeInputEl.value = originalTime;
+                await this.refreshClassTimeLock(cls);
+                this.showToast({ title:'No se pudo verificar asistencia', message:'Guardamos los demás cambios, pero deja la hora igual.', variant:'warn' });
+              }
+            }
+
+            if (canApplyTimeChange){
+              const start = new Date(`${cls.localDate||cls.classDate}T${timeInputValue}:00-06:00`);
               const end = new Date(start.getTime() + (Number(cls.duration||60)*60000));
               data.startAt = firebase.firestore.Timestamp.fromDate(start);
               data.endAt = firebase.firestore.Timestamp.fromDate(end);
               data.classDate = start.toISOString().slice(0,10);
               data.time = start.toISOString().slice(11,16);
             }
+
             await this.db.collection('classes').doc(id).set(data,{ merge:true });
             this.showToast({ title:'Clase actualizada' });
             this.hideClassModal();


### PR DESCRIPTION
## Summary
- split class detail and attendance saves so attendance updates no longer reuse the class save logic
- lock and warn on class time edits when attendance exists to avoid breaking attendance records
- ensure the class modal only shows the relevant action buttons per tab and display a read-only warning for protected times

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc48f5e69c8320af46a71070c3d7ef