### PR TITLE
Capture class time in attendance reporting

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -761,7 +761,8 @@
               if (!report[r.classDate]) return;
               const cat = r.status==='attended' ? 'attended' : 'absent';
               report[r.classDate][cat]++;
-              const key = `${r.className}`;
+              const labelBase = r.classTime ?? r.className;
+              const key = `${labelBase} - ${r.className}`;
               if (!report[r.classDate].details[cat][key]) report[r.classDate].details[cat][key] = [];
               report[r.classDate].details[cat][key].push(r.userName);
             });
@@ -1158,6 +1159,7 @@
             const ref = this.db.collection('attendance').doc(`${classDate}_${cls.id}_${uid}`);
             batch.set(ref,{
               classId: cls.id, className: cls.name, classDate,
+              classTime: cls.time || cls.localTime,
               userId: uid, userName: rec.userName, status: rec.status, recordedAt: new Date()
             },{ merge:true });
           });


### PR DESCRIPTION
## Summary
- store the class time on each attendance record that is saved from the admin panel
- include the class time when grouping attendance details so identically named classes stay separate

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc5b149650832096b83ebf29b5869d