### PR TITLE
Route TotalPass notification clicks through app toast

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,10 @@
         }
         window.showToast = showToast;
 
+        const TOTALPASS_PROMPT_PARAM = 'totalpassPrompt';
+        const TOTALPASS_URL_PARAM = 'whatsappUrl';
+        const TOTALPASS_MESSAGE_PARAM = 'whatsappMessage';
+
         let whatsappDeeplink = '';
         function showWhatsappPrompt({ url, message }) {
           if (!url) return;
@@ -251,16 +255,16 @@
           }
         }
 
-        const _whatsappPrompt = _params.get('whatsappPrompt');
-        if (_whatsappPrompt === '1') {
-          const whatsappUrl = _params.get('whatsappUrl');
-          const whatsappMessage = _params.get('whatsappMessage') || '';
+        const totalpassPrompt = _params.get(TOTALPASS_PROMPT_PARAM);
+        if (totalpassPrompt === '1') {
+          const whatsappUrl = _params.get(TOTALPASS_URL_PARAM);
+          const whatsappMessage = _params.get(TOTALPASS_MESSAGE_PARAM) || '';
           if (whatsappUrl) {
             showWhatsappPrompt({ url: whatsappUrl, message: whatsappMessage });
           }
-          _params.delete('whatsappPrompt');
-          _params.delete('whatsappUrl');
-          _params.delete('whatsappMessage');
+          _params.delete(TOTALPASS_PROMPT_PARAM);
+          _params.delete(TOTALPASS_URL_PARAM);
+          _params.delete(TOTALPASS_MESSAGE_PARAM);
           const newSearch = _params.toString();
           const newUrl = newSearch ? `${location.pathname}?${newSearch}` : location.pathname;
           if (history.replaceState) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -22,6 +22,11 @@ firebase.initializeApp({
 
 const messaging = firebase.messaging();
 
+// Parámetros usados para avisar al cliente que debe mostrar el prompt TotalPass
+const TOTALPASS_PROMPT_PARAM = "totalpassPrompt";
+const TOTALPASS_URL_PARAM = "whatsappUrl";
+const TOTALPASS_MESSAGE_PARAM = "whatsappMessage";
+
 // -------- util de log --------
 const LOG = true;
 const log = (...a) => { if (LOG) console.log("[SW]", ...a); };
@@ -118,8 +123,9 @@ self.addEventListener("notificationclick", (event) => {
         return existing.focus();
       }
 
-      const params = new URLSearchParams({ whatsappPrompt: "1", whatsappUrl });
-      if (whatsappMessage) params.set("whatsappMessage", whatsappMessage);
+      const params = new URLSearchParams({ [TOTALPASS_PROMPT_PARAM]: "1" });
+      params.set(TOTALPASS_URL_PARAM, whatsappUrl);
+      if (whatsappMessage) params.set(TOTALPASS_MESSAGE_PARAM, whatsappMessage);
       const targetUrl = `/?${params.toString()}`;
       log("Abriendo ventana con prompt TotalPass:", targetUrl);
       return clients.openWindow(targetUrl);


### PR DESCRIPTION
## Summary
- funnel TotalPass notification clicks through the PWA instead of going straight to WhatsApp
- share TotalPass prompt parameters between the service worker and the app so the toast can render the WhatsApp button and message

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc9b0bd5808320b77c1d6186f0e573