### PR TITLE
Add client-side sorting for agenda classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,6 +611,11 @@
               if (state.scheduleFilter!=='today') return true;
               const start = cls.startAt?.toDate ? cls.startAt.toDate() : new Date(`${cls.classDate}T${cls.time}:00Z`);
               return Date.now() <= start.getTime() + 5*60*1000;
+            })
+            .sort((a, b) => {
+              const startA = a.startAt?.toDate ? a.startAt.toDate() : new Date(`${a.classDate}T${a.time}:00Z`);
+              const startB = b.startAt?.toDate ? b.startAt.toDate() : new Date(`${b.classDate}T${b.time}:00Z`);
+              return startA.getTime() - startB.getTime();
             });
 
           const horarioHTML = filtered.length ? filtered.map(cls=>{


### PR DESCRIPTION
## Summary
- add client-side fallback sorting for agenda class list to ensure chronological ordering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cca4cd42a88320b3faeca22d7511e9