### PR TITLE
Fix Mexico City parsing for startAt dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,22 +117,98 @@
           get today(){ return this.getYYYYMMDD(new Date()); },
           get tomorrow(){ return this.getYYYYMMDD(new Date(Date.now()+86400000)); },
           human(ymd){
-            const dt=new Date(`${ymd}T00:00:00Z`);
+            const dt = mxDateFromYMD(ymd);
+            if (!dt) return '';
             return dt.toLocaleDateString('es-MX',{ timeZone: MX_TZ, weekday:'long',day:'2-digit',month:'short' });
           }
         };
         const timeHelper = {
           range(ymd, hhmm, durationMin=60){
-            const start=new Date(`${ymd}T${hhmm}:00Z`);
-            const end=new Date(start.getTime()+Number(durationMin||60)*60000);
+            const start = mxDateFromYMD(ymd, hhmm);
+            if (!start) return '';
+            const end = new Date(start.getTime()+Number(durationMin||60)*60000);
             return `${timeFmt.format(start)}–${timeFmt.format(end)}`;
           }
         };
-        const asDate = (x) => x?.toDate ? x.toDate() : new Date(x);
+
+        // Small helper so every manual date uses Mexico City timezone
+        function getTimeZoneOffset(tz, date){
+          const formatter = new Intl.DateTimeFormat('en-US', {
+            timeZone: tz,
+            hour12: false,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit'
+          });
+          const parts = formatter.formatToParts(date);
+          const filled = {};
+          for (const part of parts) {
+            if (part.type !== 'literal') filled[part.type] = part.value;
+          }
+          const asUTC = Date.UTC(
+            Number(filled.year || date.getUTCFullYear()),
+            Number((filled.month || String(date.getUTCMonth()+1)).padStart(2,'0'))-1,
+            Number(filled.day || String(date.getUTCDate()).padStart(2,'0')),
+            Number(filled.hour || String(date.getUTCHours()).padStart(2,'0')),
+            Number(filled.minute || String(date.getUTCMinutes()).padStart(2,'0')),
+            Number(filled.second || String(date.getUTCSeconds()).padStart(2,'0'))
+          );
+          return asUTC - date.getTime();
+        }
+
+        function mxDateFromYMD(ymd, hhmm='00:00'){
+          if (!ymd) return null;
+          const [year, month, day] = ymd.split('-').map(Number);
+          const [hour, minute] = (hhmm||'00:00').split(':').map(Number);
+          if (![year, month, day].every(n=>Number.isFinite(n))) return null;
+          const safeHour = Number.isFinite(hour) ? hour : 0;
+          const safeMinute = Number.isFinite(minute) ? minute : 0;
+          const baseUTC = new Date(Date.UTC(year, (month||1)-1, day||1, safeHour, safeMinute));
+          const offset = getTimeZoneOffset(MX_TZ, baseUTC);
+          return new Date(baseUTC.getTime()-offset);
+        }
+        function asDate(value){
+          if (value === null || value === undefined) return null;
+          if (typeof value?.toDate === 'function') {
+            const dt = value.toDate();
+            return Number.isNaN(dt?.getTime()) ? null : dt;
+          }
+          if (value instanceof Date) {
+            return Number.isNaN(value.getTime()) ? null : value;
+          }
+          let candidate = value;
+          if (typeof value === 'string') {
+            const normalized = value.replace(/\u202f/g, ' ').replace(/\s+at\s+/i, ' ');
+            const parsed = new Date(normalized);
+            if (!Number.isNaN(parsed.getTime())) return parsed;
+            candidate = value;
+          }
+          if (typeof value === 'number') {
+            const parsed = new Date(value);
+            return Number.isNaN(parsed.getTime()) ? null : parsed;
+          }
+          const parsed = new Date(candidate);
+          return Number.isNaN(parsed.getTime()) ? null : parsed;
+        }
+
+        function getLocalStart(record){
+          if (!record) return null;
+          const direct = record.startAt ? asDate(record.startAt) : null;
+          if (direct) return direct;
+          if (record.classDate) {
+            return mxDateFromYMD(record.classDate, record.time || '00:00');
+          }
+          return null;
+        }
 
         function timeUntilLabel(ymd, hhmm){
           if(!ymd||!hhmm) return '';
-          const start=new Date(`${ymd}T${hhmm}:00Z`).getTime();
+          const startDate = mxDateFromYMD(ymd, hhmm);
+          if (!startDate) return '';
+          const start=startDate.getTime();
           const now=Date.now();
           const diff=start-now;
           if (diff>4*60*60*1000) return '';
@@ -568,32 +644,34 @@
         // --- AGENDA (igual que tu implementación, con mínimos cambios)
         function getAgendaScreenHTML(){
           const upcoming = state.myBookings.filter(Boolean).filter(b=>{
-            const startObj = b.startAt ? asDate(b.startAt) : new Date(`${b.classDate}T${b.time||'00:00'}:00Z`);
+            const startObj = getLocalStart(b);
+            if (!startObj) return false;
             return Date.now() <= startObj.getTime()+5*60*1000;
           }).sort((a,b)=>{
-            const ta = a.startAt ? asDate(a.startAt).getTime() : new Date(`${a.classDate}T${a.time||'00:00'}:00Z`).getTime();
-            const tb = b.startAt ? asDate(b.startAt).getTime() : new Date(`${b.classDate}T${b.time||'00:00'}:00Z`).getTime();
-            return ta - tb;
+            const startA = getLocalStart(a);
+            const startB = getLocalStart(b);
+            return (startA?.getTime()||0) - (startB?.getTime()||0);
           });
           const reservasHTML = upcoming.length ? upcoming.map(b=>{
-            const startObj = b.startAt ? asDate(b.startAt) : new Date(`${b.classDate}T${b.time||'00:00'}:00Z`);
-            const ymdUTC = b.classDate || startObj.toISOString().slice(0,10);
-            const hhmmUTC = b.time || startObj.toISOString().slice(11,16);
-            const hhmm = timeFmt.format(startObj);
+            const startObj = getLocalStart(b);
+            if (!startObj) return '';
+            const ymdForCountdown = b.classDate || dateHelper.getYYYYMMDD(startObj);
+            const hhmmForCountdown = b.time || timeFmt.format(startObj);
             const ymdLocal = dateHelper.getYYYYMMDD(startObj);
             const dayText = ymdLocal===dateHelper.today ? 'Hoy' : ymdLocal===dateHelper.tomorrow ? 'Mañana' : dateHelper.human(ymdLocal);
             const cover = coverHelper.forClassName(b.className, b.className);
             const safeClassName = DOMPurify.sanitize(b.className || '');
             const safeDayText = DOMPurify.sanitize(dayText);
             const safeClassId = DOMPurify.sanitize(b.classId);
+            const safeTimeText = DOMPurify.sanitize(hhmmForCountdown);
             return `
               <div class="bg-zinc-800 rounded-2xl p-4 flex items-center justify-between">
                 <div class="flex items-center gap-4">
                   <img src="${cover}" alt="${safeClassName}" class="w-16 h-16 rounded-lg object-cover bg-zinc-700" loading="lazy" decoding="async">
                   <div>
                     <p class="font-bold text-lg">${safeClassName}</p>
-                    <p class="text-zinc-400 text-sm">${safeDayText} • ${hhmm}</p>
-                    <p class="text-emerald-400 text-xs mt-0.5">${timeUntilLabel(ymdUTC, hhmmUTC)}</p>
+                    <p class="text-zinc-400 text-sm">${safeDayText} • ${safeTimeText}</p>
+                    <p class="text-emerald-400 text-xs mt-0.5">${timeUntilLabel(ymdForCountdown, hhmmForCountdown)}</p>
                   </div>
                 </div>
                 <button data-action="cancel-booking" data-class-id="${safeClassId}" class="text-xs text-rose-400 hover:text-rose-300">Cancelar</button>
@@ -603,19 +681,19 @@
           const targetYMD = state.scheduleFilter==='today' ? dateHelper.today : dateHelper.tomorrow;
           const filtered = state.classes
             .filter(cls=>{
-              const start = cls.startAt?.toDate ? cls.startAt.toDate() : new Date(`${cls.classDate}T${cls.time}:00Z`);
-              const ymd = dateHelper.getYYYYMMDD(start);
+              const start = getLocalStart(cls);
+              const ymd = cls.classDate || (start ? dateHelper.getYYYYMMDD(start) : null);
               return ymd===targetYMD;
             })
             .filter(cls=>{
               if (state.scheduleFilter!=='today') return true;
-              const start = cls.startAt?.toDate ? cls.startAt.toDate() : new Date(`${cls.classDate}T${cls.time}:00Z`);
-              return Date.now() <= start.getTime() + 5*60*1000;
+              const start = getLocalStart(cls);
+              return start ? Date.now() <= start.getTime() + 5*60*1000 : false;
             })
             .sort((a, b) => {
-              const startA = a.startAt?.toDate ? a.startAt.toDate() : new Date(`${a.classDate}T${a.time}:00Z`);
-              const startB = b.startAt?.toDate ? b.startAt.toDate() : new Date(`${b.classDate}T${b.time}:00Z`);
-              return startA.getTime() - startB.getTime();
+              const startA = getLocalStart(a);
+              const startB = getLocalStart(b);
+              return (startA?.getTime()||0) - (startB?.getTime()||0);
             });
 
           const horarioHTML = filtered.length ? filtered.map(cls=>{
@@ -623,7 +701,8 @@
             const available = Number(cls.capacity||0)-enrolled;
             const isBooked = state.myBookings.some(b=>b.classId===cls.id);
             const waitEntry = state.waitlistEntries.find(w=>w.classId===cls.id); // check if user already in waitlist
-            const notified = waitEntry && waitEntry.notifiedAt && (!waitEntry.expiresAt || asDate(waitEntry.expiresAt).getTime()>Date.now()); // notified users can book even if class shows full
+            const expiresAt = waitEntry ? asDate(waitEntry.expiresAt) : null;
+            const notified = Boolean(waitEntry && waitEntry.notifiedAt && (!waitEntry.expiresAt || (expiresAt && expiresAt.getTime()>Date.now()))); // notified users can book even if class shows full
             const safeId = DOMPurify.sanitize(cls.id);
             let badge = `<span class="text-xs bg-emerald-500/50 text-emerald-300 px-2 py-1 rounded-md">¡Hay cupo!</span>`;
             if (isBooked) {
@@ -640,19 +719,23 @@
               // user has been notified of a free spot
               badge = `<span class="text-xs bg-amber-500/50 text-amber-300 px-2 py-1 rounded-md">Tu turno</span>`;
             }
-            const ymdUTC = cls.classDate || targetYMD;
-            const hhmmUTC = cls.time || cls.startAt.toDate().toISOString().slice(11,16);
-            const hhmm = timeFmt.format(new Date(`${ymdUTC}T${hhmmUTC}:00Z`));
+            const startObj = getLocalStart(cls);
+            if (!startObj) return '';
+            const ymdLocal = dateHelper.getYYYYMMDD(startObj);
+            const hhmmLocal = cls.time || timeFmt.format(startObj);
+            const countdownYMD = cls.classDate || ymdLocal;
+            const countdownHHMM = hhmmLocal;
             const safeName = DOMPurify.sanitize(cls.name || '');
             const safeInstructor = DOMPurify.sanitize(cls.instructor || '');
+            const safeTimeText = DOMPurify.sanitize(hhmmLocal);
             return `
               <div data-action="navigate-details" data-class-id="${safeId}" class="bg-zinc-800 rounded-2xl p-4 flex items-center gap-4 cursor-pointer hover:bg-zinc-700">
                 <img src="${coverHelper.forClass(cls)}" alt="${safeName}" class="w-16 h-16 rounded-lg object-cover bg-zinc-700" loading="lazy" decoding="async">
                 <div class="flex-1">
                   <p class="font-bold text-lg">${safeName}</p>
                   <p class="text-zinc-400 text-sm">con ${safeInstructor}</p>
-                  <p class="text-sm mt-1 text-emerald-400">${hhmm} hrs</p>
-                  <p class="text-emerald-300 text-xs mt-0.5">${timeUntilLabel(ymdUTC, hhmmUTC)}</p>
+                  <p class="text-sm mt-1 text-emerald-400">${safeTimeText} hrs</p>
+                  <p class="text-emerald-300 text-xs mt-0.5">${timeUntilLabel(countdownYMD, countdownHHMM)}</p>
                 </div>
                 <div class="text-right">${badge}</div>
               </div>`;
@@ -728,11 +811,13 @@
             const availableSpots = Number(cls.capacity||0)-enrolled;
             const isBooked = state.myBookings.some(b=>b.classId===cls.id);
             const waitEntry = state.waitlistEntries.find(w=>w.classId===cls.id); // user's waitlist entry if any
-            const notified = waitEntry && waitEntry.notifiedAt && (!waitEntry.expiresAt || asDate(waitEntry.expiresAt).getTime()>Date.now()); // true if user has active waitlist notification
+            const expiresAt = waitEntry ? asDate(waitEntry.expiresAt) : null;
+            const notified = Boolean(waitEntry && waitEntry.notifiedAt && (!waitEntry.expiresAt || (expiresAt && expiresAt.getTime()>Date.now()))); // true if user has active waitlist notification
             const durationMin = Number(cls.duration||60);
-            const ymdUTC = cls.classDate || cls.startAt.toDate().toISOString().slice(0,10);
-            const hhmmUTC = cls.time || cls.startAt.toDate().toISOString().slice(11,16);
-            const timeRange = timeHelper.range(ymdUTC, hhmmUTC, durationMin);
+            const startObj = getLocalStart(cls);
+            const ymdLocal = cls.classDate || (startObj ? dateHelper.getYYYYMMDD(startObj) : null);
+            const hhmmLocal = cls.time || (startObj ? timeFmt.format(startObj) : null);
+            const timeRange = ymdLocal && hhmmLocal ? timeHelper.range(ymdLocal, hhmmLocal, durationMin) : '';
             const safeName = DOMPurify.sanitize(cls.name || '');
             const safeDesc = DOMPurify.sanitize(cls.description || '');
             const safeId = DOMPurify.sanitize(cls.id);
@@ -814,7 +899,8 @@
             const userRef = db.collection('users').doc(uid);
             const waitRef = db.collection('waitlists').doc(`${classId}_${uid}`);
             const waitEntry = state.waitlistEntries.find(w=>w.classId===classId); // user's waitlist entry
-            const notified = waitEntry && waitEntry.notifiedAt && (!waitEntry.expiresAt || asDate(waitEntry.expiresAt).getTime()>Date.now()); // valid notification
+            const expiresAt = waitEntry ? asDate(waitEntry.expiresAt) : null;
+            const notified = Boolean(waitEntry && waitEntry.notifiedAt && (!waitEntry.expiresAt || (expiresAt && expiresAt.getTime()>Date.now()))); // valid notification
             try{
               await db.runTransaction(async tx=>{
                 const [classSnap, bookingSnap, userSnap, waitSnap] = await Promise.all([
@@ -830,8 +916,9 @@
                 const enrolled = Number(cls.enrolledCount||0);
                 const capacity = Number(cls.capacity||0);
                 if (enrolled>=capacity && !notified) throw new Error('Clase llena.');
-                const startAtTs = cls.startAt?.toDate ? cls.startAt : firebase.firestore.Timestamp.fromDate(new Date(cls.startAt));
-                const startDateObj = cls.startAt?.toDate ? cls.startAt.toDate() : new Date(cls.startAt);
+                const startDateObj = getLocalStart(cls);
+                if (!startDateObj) throw new Error('Clase sin fecha de inicio válida.');
+                const startAtTs = cls.startAt?.toDate ? cls.startAt : firebase.firestore.Timestamp.fromDate(startDateObj);
                 const classDate = cls.classDate || dateHelper.getYYYYMMDD(startDateObj);
                 const time = cls.time || timeFmt.format(startDateObj);
                 tx.set(bookingRef, {


### PR DESCRIPTION
## Summary
- add resilient `asDate` and `getLocalStart` helpers so Firestore timestamps and formatted strings resolve to Mexico City dates
- reuse the new helpers across agenda listings and class details so all displayed times honor the Mexico City timezone
- ensure booking transactions derive classDate/time from the normalized Mexico City start date before saving

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cca932ac248320bff7ad2706a7bd8c