### PR TITLE
Fix navigateTo method syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -885,7 +885,7 @@
                 .catch(err=>{ alert('Error: '+err.message); loadingSpinner.classList.add('hidden'); });
             }
           },
-          navigateTo: (screen, data={}){
+          navigateTo: (screen, data={})=>{
             if (screen==='agenda') attachAgendaListeners(); else detachListeners();
             state.currentScreen = screen;
             if (data.classId) state.selectedClassId = data.classId;


### PR DESCRIPTION
## Summary
- fix navigateTo handler to use arrow function syntax when defined inside the app object literal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccaf57316c83209c03c4d1934b0553