### PR TITLE
Update daily class generator to weekly schedule

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -45,7 +45,7 @@
 
       <div class="mb-6 flex flex-wrap gap-3">
         <button id="gen-classes-btn" class="bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-3 px-6 rounded-lg">
-          <i data-lucide="calendar-check" class="inline-block -mt-1 mr-2"></i>Generar/Verificar Clases (Hoy/Mañana)
+          <i data-lucide="calendar-check" class="inline-block -mt-1 mr-2"></i>Generar/Verificar Clases (Próxima Semana)
         </button>
         <button id="create-class-btn" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg">
           <i data-lucide="plus" class="inline-block -mt-1 mr-2"></i>Crear Nueva Clase


### PR DESCRIPTION
## Summary
- update the scheduled Cloud Function to run every Saturday afternoon and queue classes for the following Monday through Saturday
- adjust console logging and documentation so the function reflects the new weekly behavior
- refresh the admin panel trigger button label so staff sees the weekly scope

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1948cdce08320928cc4ae761c154e