### PR TITLE
Use direct navigation for TotalPass WhatsApp link

### DIFF
--- a/index.html
+++ b/index.html
@@ -957,7 +957,7 @@
                     primary: true,
                     callback: () => {
                       const whatsappUrl = `https://api.whatsapp.com/send?phone=5215539887713&text=${encodeURIComponent('Hola! Aqui te mando mi codigo de TotalPass: ')}`;
-                      window.open(whatsappUrl, '_blank', 'noopener,noreferrer');
+                      window.location.href = whatsappUrl;
                       showToast('WhatsApp abierto para enviar token', 'success');
                     }
                   }


### PR DESCRIPTION
## Summary
- replace the TotalPass WhatsApp window.open call with window.location.href for direct navigation

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d204b2b6388320a77fb8e2919fafa3