### PR TITLE
Add single TotalPass daily token action

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,24 +585,25 @@
               .filter(Boolean)
               .sort((a, b) => b.startObj.getTime() - a.startObj.getTime());
 
-            completadasHTML = completed.length ? completed.map(({ booking, startObj, relatedClass }) => {
-              const className = booking.className || relatedClass?.name || '';
-              const cover = relatedClass ? coverHelper.forClass(relatedClass) : coverHelper.forClassName(className, className);
-              const safeClassName = DOMPurify.sanitize(className);
-              const safeClassId = DOMPurify.sanitize(booking.classId);
-              const hhmm = timeFmt.format(startObj);
-              return `
-                <div class="bg-zinc-800 rounded-2xl p-4 flex items-center justify-between">
-                  <div class="flex items-center gap-4">
+              completadasHTML = completed.length ? completed.map(({ booking, startObj, relatedClass }) => {
+                const className = booking.className || relatedClass?.name || '';
+                const cover = relatedClass ? coverHelper.forClass(relatedClass) : coverHelper.forClassName(className, className);
+                const safeClassName = DOMPurify.sanitize(className);
+                const hhmm = timeFmt.format(startObj);
+                return `
+                  <div class="bg-zinc-800 rounded-2xl p-4 flex items-center gap-4">
                     <img src="${cover}" alt="${safeClassName}" class="w-16 h-16 rounded-lg object-cover bg-zinc-700" loading="lazy" decoding="async">
                     <div>
                       <p class="font-bold text-lg">${safeClassName}</p>
                       <p class="text-zinc-400 text-sm">Hoy • ${hhmm}</p>
                     </div>
-                  </div>
-                  <button data-action="send-totalpass" data-class-id="${safeClassId}" class="text-xs bg-emerald-600 hover:bg-emerald-700 text-white font-semibold px-3 py-2 rounded-lg">Enviar Token</button>
-                </div>`;
-            }).join('') : `<div class="bg-zinc-800 rounded-2xl p-5 text-center text-zinc-400">Aún no terminas clases hoy.</div>`;
+                  </div>`;
+              }).join('') : `<div class="bg-zinc-800 rounded-2xl p-5 text-center text-zinc-400">Aún no terminas clases hoy.</div>`;
+
+              const singleTokenButton = completed.length > 0 ?
+                `<button data-action="send-totalpass-daily" class="w-full mt-4 bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-3 rounded-lg">Enviar Token del Día</button>` : '';
+
+              completadasHTML += singleTokenButton;
           }
 
           const targetYMD = state.scheduleFilter==='today' ? dateHelper.today : dateHelper.tomorrow;
@@ -939,30 +940,10 @@
             case 'cancel-booking': target.disabled=true; app.cancelBooking(classId).finally(()=>target.disabled=false); break;
             case 'join-waitlist': target.disabled=true; app.joinWaitlist(classId).finally(()=>target.disabled=false); break;
             case 'leave-waitlist': target.disabled=true; app.leaveWaitlist(classId).finally(()=>target.disabled=false); break;
-            case 'send-totalpass': {
-              const classInfo = state.classes.find(c=>c.id===classId) || state.myBookings.find(b=>b.classId===classId);
-              const className = classInfo?.name || classInfo?.className || '';
-
-              showModal({
-                title: '¿Abrir WhatsApp?',
-                message: 'Se abrirá WhatsApp para enviar tu código de TotalPass.',
-                buttons: [
-                  {
-                    text: 'Cancelar',
-                    primary: false,
-                    callback: null
-                  },
-                  {
-                    text: 'Abrir WhatsApp',
-                    primary: true,
-                    callback: () => {
-                      const whatsappUrl = `https://api.whatsapp.com/send?phone=5215539887713&text=${encodeURIComponent('Hola! Aqui te mando mi codigo de TotalPass: ')}`;
-                      window.location.href = whatsappUrl;
-                      showToast('WhatsApp abierto para enviar token', 'success');
-                    }
-                  }
-                ]
-              });
+            case 'send-totalpass-daily': {
+              const whatsappUrl = `https://api.whatsapp.com/send?phone=5215539887713&text=${encodeURIComponent('Hola! Aqui te mando mi codigo de TotalPass: ')}`;
+              window.open(whatsappUrl, '_blank', 'noopener,noreferrer');
+              showToast('WhatsApp abierto para enviar token del día', 'success');
               break;
             }
           }


### PR DESCRIPTION
## Summary
- remove per-class TotalPass buttons from the completed classes list and add one consolidated daily token button
- handle the new daily TotalPass action by opening WhatsApp and showing confirmation feedback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d20663da1083209caaef0e0cb28661