### PR TITLE
Fix late cancellation enforcement using server time

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -33,8 +33,8 @@ service cloud.firestore {
       allow read: if true;
       allow create, update, delete: if isAdmin();
 
-      // Members can nudge the enrollment count by one.
-      // First booking initializes the count when it is missing.
+      // Members can only increment the enrollment count during booking.
+      // Decrements must go through server-side cancellation logic.
       allow update: if isAdmin() ||
       (
         isSignedIn()
@@ -46,10 +46,7 @@ service cloud.firestore {
           )
           || (
             resource.data.enrolledCount != null
-            && (
-              request.resource.data.enrolledCount == resource.data.enrolledCount + 1 ||
-              request.resource.data.enrolledCount == resource.data.enrolledCount - 1
-            )
+            && request.resource.data.enrolledCount == resource.data.enrolledCount + 1
           )
         )
       );
@@ -65,7 +62,9 @@ service cloud.firestore {
         && request.resource.data.className is string
         && request.resource.data.startAt is timestamp
         && cooldownOk(request.auth.uid);
-      allow update, delete: if (isSignedIn() && resource.data.userId == request.auth.uid) || isAdmin();
+      // Booking cancellations must go through the callable Cloud Function.
+      allow update: if isAdmin();
+      allow delete: if isAdmin();
     }
 
     // ===== USERS (Final, Simpler Ruleset) =====
@@ -78,17 +77,10 @@ service cloud.firestore {
           isSignedIn()
           && request.auth.uid == userId
           && request.resource.data.diff(resource.data).changedKeys().hasOnly([
-            'fcmTokens', 'fcmUpdatedAt', 'displayName', 'photoURL', 'lastActivity', 'lastCancelAt', 'totalPass', 'lateCancellations', 'blacklisted', 'blacklistedAt'
+            'fcmTokens', 'fcmUpdatedAt', 'displayName', 'photoURL', 'lastActivity', 'totalPass'
           ])
           && request.resource.data.email == resource.data.email
           && request.resource.data.createdAt == resource.data.createdAt
-          && (!('lateCancellations' in request.resource.data) ||
-            !('lateCancellations' in resource.data) ||
-            request.resource.data.lateCancellations >= resource.data.lateCancellations)
-          && (!('blacklisted' in request.resource.data) ||
-            request.resource.data.blacklisted == resource.data.blacklisted ||
-            (request.resource.data.blacklisted == true && resource.data.blacklisted != true))
-          && (!('blacklistedAt' in request.resource.data) || request.resource.data.blacklisted == true)
       ) ||
       isAdmin();
     }

--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-messaging-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-functions-compat.js"></script>
 
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
@@ -100,6 +101,8 @@
         const db = firebase.firestore();
         const auth = firebase.auth();
         const messaging = firebase.messaging();
+        const functionsSvc = firebase.app().functions('us-central1');
+        const cancelBookingCallable = functionsSvc.httpsCallable('cancelBooking');
 
         // ---- Enable client cache (multi-tab safe)
         try {
@@ -892,8 +895,8 @@
           },
           cancelBooking: async (classId)=>{
             const uid = state.currentUser.uid;
-            const classRef = db.collection('classes').doc(classId);
-            const bookingRef = db.collection('bookings').doc(`${classId}_${uid}`);
+            if (!classId) return;
+
             const userRef = db.collection('users').doc(uid);
 
             const isValidDate = (value) => value instanceof Date && !Number.isNaN(value.getTime());
@@ -934,55 +937,14 @@
             if (!confirm(confirmMessage)) return;
 
             try{
-              let becameBlacklisted = false;
-              let resultingLateCount = currentLateCount;
-              let recordedLateStrike = false;
-              await db.runTransaction(async tx=>{
-                const [bookingSnap, classSnap, userSnap] = await Promise.all([
-                  tx.get(bookingRef),
-                  tx.get(classRef),
-                  tx.get(userRef)
-                ]);
-                if (!bookingSnap.exists) throw new Error('No tienes reserva para esta clase.');
+              const response = await cancelBookingCallable({ classId });
+              const data = response?.data || {};
+              const becameBlacklisted = data.becameBlacklisted === true;
+              const recordedLateStrike = data.recordedLateStrike === true;
+              const resultingLateCount = Number.isFinite(Number(data.resultingLateCount))
+                ? Number(data.resultingLateCount)
+                : currentLateCount;
 
-                const classData = classSnap.exists ? classSnap.data() : null;
-                const bookingData = bookingSnap.data() || {};
-                const startDate = resolveStartDate(bookingData, classData);
-                const lateCancellation = isValidDate(startDate)
-                  ? (startDate.getTime() - Date.now()) <= TWO_HOURS_MS
-                  : true;
-
-                if (classSnap.exists){
-                  const enrolled = Number(classData?.enrolledCount || 0);
-                  if (enrolled > 0) {
-                    tx.update(classRef,{ enrolledCount: firebase.firestore.FieldValue.increment(-1) });
-                  }
-                }
-
-                const userData = userSnap.exists ? userSnap.data() : {};
-                const baseLate = Number(userData.lateCancellations || 0);
-                const userUpdates = {
-                  lastCancelAt: firebase.firestore.FieldValue.serverTimestamp()
-                };
-
-                if (lateCancellation) {
-                  recordedLateStrike = true;
-                  const nextLate = Math.min(baseLate + 1, 3);
-                  userUpdates.lateCancellations = nextLate;
-                  resultingLateCount = nextLate;
-                  if (nextLate >= 3 && userData.blacklisted !== true) {
-                    userUpdates.blacklisted = true;
-                    userUpdates.blacklistedAt = firebase.firestore.FieldValue.serverTimestamp();
-                    becameBlacklisted = true;
-                  }
-                } else {
-                  resultingLateCount = baseLate;
-                }
-
-                tx.set(userRef, userUpdates, { merge: true });
-              });
-
-              await bookingRef.delete();
               showModal({ success:false, title:'Cancelación Exitosa' });
 
               if (becameBlacklisted) {
@@ -990,7 +952,10 @@
               } else if (recordedLateStrike) {
                 showToast(`Cancelación tardía registrada. Strikes: ${resultingLateCount}/3`, 'error');
               }
-            }catch(err){ alert(`No se pudo cancelar\n\n${err.message}`); }
+            }catch(err){
+              const errMessage = err?.details?.message || err?.message || 'Error desconocido.';
+              alert(`No se pudo cancelar\n\n${errMessage}`);
+            }
           },
           joinWaitlist: async (classId)=>{
             const uid = state.currentUser.uid;


### PR DESCRIPTION
## Summary
- add a callable Cloud Function that cancels bookings and tallies strikes with the server clock
- update the client to load Firebase Functions and call the server-backed cancellation flow
- tighten Firestore rules so only admins/cloud functions can delete bookings, forcing server-side cancellation logic
- harden Firestore rules so only bookings and server logic can decrement class enrollment or touch late-cancellation strike fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d31d6f16508320b2aaee439533c5ee