### PR TITLE
Make attendance and notifications sections collapsible

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -132,12 +132,12 @@
             data-expanded-label="Colapsar"
             data-collapsed-label="Expandir"
             aria-controls="attendance-section-body"
-            aria-expanded="true"
+            aria-expanded="false"
           >
-            <span data-toggle-label>Colapsar</span>
+            <span data-toggle-label>Expandir</span>
           </button>
         </div>
-        <div id="attendance-section-body" class="space-y-4">
+        <div id="attendance-section-body" class="space-y-4 hidden">
           <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between text-xs text-zinc-400 gap-2">
             <div class="flex items-center gap-4">
               <span id="att-last">Última actualización: —</span>
@@ -166,6 +166,24 @@
           </div>
           <div id="attendance-details" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 text-sm"></div>
         </div>
+      </section>
+
+      <section class="mt-8 p-6 bg-zinc-800 rounded-lg" aria-labelledby="notifs-title">
+        <div class="flex items-center justify-between gap-4 mb-4">
+          <h2 id="notifs-title" class="text-2xl font-bold">Últimas 10 notificaciones</h2>
+          <button
+            type="button"
+            class="toggle-section inline-flex items-center gap-1 text-xs font-semibold text-indigo-400 hover:text-indigo-300"
+            data-toggle-target="recent-notifs"
+            data-expanded-label="Colapsar"
+            data-collapsed-label="Expandir"
+            aria-controls="recent-notifs"
+            aria-expanded="false"
+          >
+            <span data-toggle-label>Expandir</span>
+          </button>
+        </div>
+        <ul id="recent-notifs" class="space-y-2 text-sm hidden"></ul>
       </section>
 
       <section class="mt-8 p-6 bg-zinc-800 rounded-lg" aria-labelledby="usuarios-title">
@@ -206,23 +224,6 @@
         </div>
         <p id="blacklisted-users-feedback" class="text-xs text-zinc-400 mt-3 hidden"></p>
         <div id="blacklisted-users-container" class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4"></div>
-      </section>
-      <section class="mt-8 p-6 bg-zinc-800 rounded-lg" aria-labelledby="notifs-title">
-        <div class="flex items-center justify-between gap-4 mb-4">
-          <h2 id="notifs-title" class="text-2xl font-bold">Últimas 10 notificaciones</h2>
-          <button
-            type="button"
-            class="toggle-section inline-flex items-center gap-1 text-xs font-semibold text-indigo-400 hover:text-indigo-300"
-            data-toggle-target="recent-notifs"
-            data-expanded-label="Colapsar"
-            data-collapsed-label="Expandir"
-            aria-controls="recent-notifs"
-            aria-expanded="true"
-          >
-            <span data-toggle-label>Colapsar</span>
-          </button>
-        </div>
-        <ul id="recent-notifs" class="space-y-2 text-sm"></ul>
       </section>
     </div>
 


### PR DESCRIPTION
## Summary
- collapse the attendance report section by default while keeping toggle support
- relocate the recent notifications panel directly below the attendance report and collapse it by default

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d49a9fa5b88320a17ef41ffcfc8a5d