### PR TITLE
Show only today's column on mobile admin calendar

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -157,17 +157,43 @@
         border-color: rgba(99, 102, 241, 0.7);
         box-shadow: inset 0 0 0 2px rgba(129, 140, 248, 0.35);
       }
+      .day-label.today-label {
+        background: rgba(67, 56, 202, 0.35);
+        border-color: rgba(99, 102, 241, 0.7);
+        color: #e0e7ff;
+      }
       @media (max-width: 1024px) {
         .calendar-header,
         .calendar-grid {
           grid-template-columns: 70px repeat(7, 180px);
         }
       }
+      @media (max-width: 768px) {
+        .calendar-container .min-w-[960px] {
+          min-width: 0;
+        }
+        .calendar-header,
+        .calendar-grid {
+          grid-template-columns: 60px 1fr;
+        }
+        .calendar-header .day-label {
+          display: none;
+        }
+        .calendar-header .day-label.today-label {
+          display: block;
+        }
+        .calendar-grid .day-grid {
+          display: none;
+        }
+        .calendar-grid .day-grid.today-column {
+          display: block;
+        }
+      }
       @media (max-width: 640px) {
         :root { --hour-height: 52px; }
         .calendar-header,
         .calendar-grid {
-          grid-template-columns: 60px repeat(7, 160px);
+          grid-template-columns: 60px 1fr;
         }
         .class-block {
           font-size: 0.7rem;
@@ -1282,6 +1308,13 @@
           const todayStr = this.dateHelper.today();
           const today = new Date(`${todayStr}T00:00:00-06:00`);
           const dow = Number.isNaN(today.getTime()) ? -1 : today.getUTCDay();
+          const headerOrder = [1, 2, 3, 4, 5, 6, 0];
+          const headerLabels = document.querySelectorAll('.calendar-header .day-label');
+          headerLabels.forEach((label, index) => {
+            const labelDay = headerOrder[index] ?? null;
+            if (dow >= 0 && labelDay === dow) label.classList.add('today-label');
+            else label.classList.remove('today-label');
+          });
           document.querySelectorAll('.day-grid').forEach(grid => {
             const index = Number(grid.dataset.dayIndex);
             if (index === dow){ grid.classList.add('today-column'); }


### PR DESCRIPTION
## Summary
- highlight today's column and header label in the admin calendar
- collapse the admin calendar grid to only today's column on small screens while keeping the full week on desktop

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db2b3d10548320a0dd885ef723fe05