### PR TITLE
Adjust attendance default date range

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -2075,9 +2075,8 @@
         getDefaultAttendanceRange(){
           const today = this.dateHelper.today();
           const end = new Date(`${today}T00:00:00-06:00`);
-          end.setDate(end.getDate()+1);
           const start = new Date(end);
-          start.setDate(start.getDate()-3);
+          start.setDate(start.getDate()-2);
           return { start: this.dateHelper.ymd(start), end: this.dateHelper.ymd(end) };
         },
         getSelectedAttendanceRange(){


### PR DESCRIPTION
## Summary
- update the default attendance report range so it covers the last two days ending today

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd62d7c5988320866093d235633e7f