### PR TITLE
Expand attendance tab window to 48 hours

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -2550,7 +2550,7 @@
           if (!cls || !cls.classDate || !cls.time) return false;
           const start = new Date(`${cls.classDate}T${cls.time}:00Z`).getTime();
           const now = Date.now();
-          const lower = now - (15*60*60*1000);
+          const lower = now - (2*24*60*60*1000);
           const upper = now + (30*60*1000);
           return (start>=lower) && (start<=upper);
         },


### PR DESCRIPTION
## Summary
- extend the admin modal helper so the attendance tab stays visible for classes up to 48 hours in the past

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6ee951188320b588a55f32eb7782