### PR TITLE
Add daily message system for agenda notifications

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -464,6 +464,29 @@
         <ul id="recent-notifs" class="space-y-2 text-sm hidden"></ul>
       </section>
 
+      <section class="mt-8 p-6 bg-zinc-800 rounded-lg" aria-labelledby="daily-message-title">
+        <div class="flex items-center justify-between gap-4 mb-4">
+          <h2 id="daily-message-title" class="text-2xl font-bold">Mensaje del Día</h2>
+        </div>
+        <form id="daily-message-form" class="space-y-4">
+          <input type="hidden" id="daily-message-id">
+          <div>
+            <label for="daily-message-text" class="block text-sm font-medium text-zinc-300 mb-2">Mensaje para los alumnos</label>
+            <textarea id="daily-message-text" class="w-full bg-zinc-700 text-white p-3 rounded-md h-28" placeholder="Ej: Está lloviendo hoy, maneja con cuidado." required></textarea>
+            <p id="daily-message-form-status" class="text-xs text-indigo-300 mt-2 hidden"></p>
+          </div>
+          <label class="inline-flex items-center gap-2 text-sm text-zinc-300">
+            <input type="checkbox" id="daily-message-active" class="w-4 h-4 accent-indigo-600" checked>
+            Mostrar mensaje en la app
+          </label>
+          <div class="flex flex-wrap gap-2">
+            <button type="submit" id="daily-message-submit" class="bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded-md">Guardar Mensaje</button>
+            <button type="button" id="daily-message-reset" class="bg-zinc-600 hover:bg-zinc-700 text-white font-bold py-2 px-4 rounded-md">Limpiar</button>
+          </div>
+        </form>
+        <div id="daily-messages-list" class="mt-6 space-y-3 text-sm"></div>
+      </section>
+
       <section class="mt-8 p-6 bg-zinc-800 rounded-lg" aria-labelledby="usuarios-title">
         <h2 id="usuarios-title" class="text-2xl font-bold mb-4">Gestión de Usuarios</h2>
 
@@ -644,7 +667,9 @@
           selectedPeriod: 'range',
           selectedClassType: 'all',
           selectedInstructor: 'all',
-          selectedExportFormat: 'capacity'
+          selectedExportFormat: 'capacity',
+          dailyMessages: [],
+          unsubDailyMessages: null
         },
 
         // --- Helpers ---
@@ -778,6 +803,9 @@
           const classFilter = document.getElementById('class-filter');
           const instructorFilter = document.getElementById('instructor-filter');
           const exportFormatEl = document.getElementById('att-export-format');
+          const dailyForm = document.getElementById('daily-message-form');
+          const dailyResetBtn = document.getElementById('daily-message-reset');
+          const dailyList = document.getElementById('daily-messages-list');
           const metricCheckboxes = [
             { id:'metric-attended', key:'attended' },
             { id:'metric-absent', key:'absent' },
@@ -834,6 +862,18 @@
             exportBtn.onclick = () => this.exportCapacityReport();
           }
 
+          if (dailyForm){
+            dailyForm.addEventListener('submit', (e)=>this.submitDailyMessage(e));
+          }
+          if (dailyResetBtn){
+            dailyResetBtn.addEventListener('click', ()=>this.resetDailyMessageForm());
+          }
+          if (dailyList){
+            dailyList.addEventListener('click', (e)=>this.handleDailyMessageListClick(e));
+          }
+
+          this.resetDailyMessageForm();
+
           this.setupSectionToggles();
 
           // Users: find + list
@@ -851,6 +891,7 @@
                   this.listenWeeklyClasses();
                   this.startAttendancePolling();
                   this.listenRecentNotifications();
+                  this.listenDailyMessages();
                 } catch(e){
                   this.showToast({ title:'Error al iniciar', message:e.message, variant:'error' });
                 }
@@ -865,8 +906,13 @@
               if (this.state.unsubClasses) this.state.unsubClasses();
               this.stopAttendancePolling();
               if (this.state.unsubRecentNotifs) this.state.unsubRecentNotifs();
+              if (this.state.unsubDailyMessages) this.state.unsubDailyMessages();
+              this.state.unsubDailyMessages = null;
               this.state.recentNotifications = [];
               this.renderRecentNotifications();
+              this.state.dailyMessages = [];
+              this.renderDailyMessages();
+              this.resetDailyMessageForm();
               this.stopCurrentTimeTicker();
             }
           });
@@ -1169,6 +1215,164 @@
                 </li>`;
             }).join('');
           },
+
+        listenDailyMessages(){
+          if (this.state.unsubDailyMessages) { this.state.unsubDailyMessages(); this.state.unsubDailyMessages = null; }
+          this.state.unsubDailyMessages = this.db.collection('dailyMessages')
+            .orderBy('createdAt', 'desc')
+            .limit(20)
+            .onSnapshot((snap)=>{
+              this.state.dailyMessages = snap.docs.map(doc=>({ id: doc.id, ...doc.data() }));
+              this.renderDailyMessages();
+            }, err=>{
+              console.error(err);
+              this.showToast({ title:'Error cargando mensajes diarios', message: err.message, variant:'error' });
+            });
+        },
+
+        renderDailyMessages(){
+          const list = document.getElementById('daily-messages-list');
+          if (!list) return;
+          if (!this.state.dailyMessages.length){
+            list.innerHTML = '<p class="text-sm text-zinc-400">No hay mensajes guardados.</p>';
+            return;
+          }
+          list.innerHTML = this.state.dailyMessages.map(msg=>{
+            const safeId = DOMPurify.sanitize(msg.id || '');
+            const sanitized = DOMPurify.sanitize(msg.message || '');
+            const formatted = sanitized.replace(/\n/g,'<br>') || '<span class="text-zinc-400">(Sin contenido)</span>';
+            const createdAt = msg.createdAt?.toDate ? msg.createdAt.toDate() : null;
+            const createdLabel = createdAt ? `${this.dayShortFmt.format(createdAt)} ${this.timeFmt.format(createdAt)}` : 'Sin fecha';
+            const safeCreated = DOMPurify.sanitize(createdLabel);
+            const creator = msg.createdBy ? DOMPurify.sanitize(String(msg.createdBy)) : '';
+            const statusBadge = msg.isActive
+              ? '<span class="px-2 py-1 rounded-md bg-emerald-500/20 text-emerald-300 text-xs">Activo</span>'
+              : '<span class="px-2 py-1 rounded-md bg-zinc-700 text-zinc-300 text-xs">Inactivo</span>';
+            const creatorLine = creator ? `<span class="text-xs text-zinc-500">Creado por: ${creator}</span>` : '';
+            return `
+              <article class="bg-zinc-900/60 border border-zinc-700 rounded-lg p-4 space-y-3">
+                <div class="flex items-start justify-between gap-3">
+                  <div class="flex-1 space-y-2">
+                    <p class="text-sm leading-relaxed text-zinc-100">${formatted}</p>
+                    <div class="flex flex-wrap gap-3 text-xs text-zinc-400">
+                      <span>${safeCreated}</span>
+                      ${creatorLine}
+                    </div>
+                  </div>
+                  ${statusBadge}
+                </div>
+                <div class="flex flex-wrap gap-2">
+                  <button type="button" class="bg-zinc-700 hover:bg-zinc-600 text-white font-semibold py-1 px-3 rounded-md" data-daily-action="edit" data-id="${safeId}">Editar</button>
+                  <button type="button" class="${msg.isActive ? 'bg-rose-600 hover:bg-rose-700' : 'bg-emerald-600 hover:bg-emerald-700'} text-white font-semibold py-1 px-3 rounded-md" data-daily-action="toggle" data-id="${safeId}" data-active="${msg.isActive?'true':'false'}">${msg.isActive ? 'Desactivar' : 'Activar'}</button>
+                </div>
+              </article>`;
+          }).join('');
+        },
+
+        resetDailyMessageForm(){
+          const idInput = document.getElementById('daily-message-id');
+          const textArea = document.getElementById('daily-message-text');
+          const activeInput = document.getElementById('daily-message-active');
+          const statusEl = document.getElementById('daily-message-form-status');
+          const submitBtn = document.getElementById('daily-message-submit');
+          if (idInput) idInput.value = '';
+          if (textArea) textArea.value = '';
+          if (activeInput) activeInput.checked = true;
+          if (statusEl){
+            statusEl.textContent = '';
+            statusEl.classList.add('hidden');
+          }
+          if (submitBtn) submitBtn.textContent = 'Guardar Mensaje';
+        },
+
+        populateDailyMessageForm(msg){
+          const idInput = document.getElementById('daily-message-id');
+          const textArea = document.getElementById('daily-message-text');
+          const activeInput = document.getElementById('daily-message-active');
+          const statusEl = document.getElementById('daily-message-form-status');
+          const submitBtn = document.getElementById('daily-message-submit');
+          if (!idInput || !textArea || !activeInput || !submitBtn) return;
+          if (!msg){
+            this.resetDailyMessageForm();
+            return;
+          }
+          idInput.value = msg.id || '';
+          textArea.value = msg.message || '';
+          activeInput.checked = !!msg.isActive;
+          if (submitBtn) submitBtn.textContent = 'Actualizar Mensaje';
+          if (statusEl){
+            const createdAt = msg.createdAt?.toDate ? msg.createdAt.toDate() : null;
+            const label = createdAt ? `${this.dayShortFmt.format(createdAt)} ${this.timeFmt.format(createdAt)}` : 'Sin fecha';
+            statusEl.textContent = `Editando mensaje (${label})`;
+            statusEl.classList.remove('hidden');
+          }
+        },
+
+        handleDailyMessageListClick(event){
+          const btn = event.target.closest('[data-daily-action]');
+          if (!btn) return;
+          const id = btn.dataset.id;
+          if (!id) return;
+          const action = btn.dataset.dailyAction;
+          if (action === 'edit'){
+            const msg = this.state.dailyMessages.find(m=>m.id===id);
+            if (msg) this.populateDailyMessageForm(msg);
+          } else if (action === 'toggle'){
+            const active = btn.dataset.active === 'true';
+            this.toggleDailyMessage(id, active);
+          }
+        },
+
+        async toggleDailyMessage(id, currentlyActive){
+          try{
+            await this.db.collection('dailyMessages').doc(id).update({
+              isActive: !currentlyActive,
+              updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+            });
+            this.showToast({ title: !currentlyActive ? 'Mensaje activado' : 'Mensaje desactivado' });
+          }catch(err){
+            console.error(err);
+            this.showToast({ title:'Error actualizando mensaje', message: err.message, variant:'error' });
+          }
+        },
+
+        async submitDailyMessage(event){
+          event.preventDefault();
+          const idInput = document.getElementById('daily-message-id');
+          const textArea = document.getElementById('daily-message-text');
+          const activeInput = document.getElementById('daily-message-active');
+          if (!textArea || !activeInput) return;
+          const docId = idInput?.value.trim();
+          const message = textArea.value.trim();
+          const isActive = !!activeInput.checked;
+          if (!message){
+            this.showToast({ title:'Escribe un mensaje', variant:'warn' });
+            return;
+          }
+          const payload = {
+            message,
+            isActive,
+            updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+          };
+          try{
+            if (docId){
+              await this.db.collection('dailyMessages').doc(docId).update(payload);
+              this.showToast({ title:'Mensaje actualizado' });
+            } else {
+              const createData = {
+                ...payload,
+                createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+                createdBy: this.auth.currentUser?.uid || ''
+              };
+              await this.db.collection('dailyMessages').add(createData);
+              this.showToast({ title:'Mensaje creado' });
+            }
+            this.resetDailyMessageForm();
+          }catch(err){
+            console.error(err);
+            this.showToast({ title:'Error guardando mensaje', message: err.message, variant:'error' });
+          }
+        },
 
         // --- GENERACIÓN (startAt/endAt) ---
         _buildStartEnd(dateStr, timeStr, duration=60){

--- a/index.html
+++ b/index.html
@@ -178,7 +178,8 @@
           scheduleFilter: 'today',
           selectedClassId: null,
           isTotalPass: false,
-          cancellationStrikes: 0
+          cancellationStrikes: 0,
+          dailyMessage: null
         };
 
         // ---- Render batching
@@ -219,12 +220,14 @@
         window.showToast = showToast;
 
         // Firestore listeners
-        let unsubClasses=null, unsubMyBookings=null, unsubWaitlist=null, unsubUser=null, listenersAttached=false;
+        let unsubClasses=null, unsubMyBookings=null, unsubWaitlist=null, unsubUser=null, unsubDailyMessage=null, listenersAttached=false;
         function detachListeners(){
           if (unsubClasses){ try{unsubClasses();}catch{}; unsubClasses=null; }
           if (unsubMyBookings){ try{unsubMyBookings();}catch{}; unsubMyBookings=null; }
           if (unsubWaitlist){ try{unsubWaitlist();}catch{}; unsubWaitlist=null; }
           if (unsubUser){ try{unsubUser();}catch{}; unsubUser=null; }
+          if (unsubDailyMessage){ try{unsubDailyMessage();}catch{}; unsubDailyMessage=null; }
+          state.dailyMessage = null;
           listenersAttached=false;
         }
         function attachAgendaListeners(){
@@ -254,6 +257,15 @@
               state.cancellationStrikes = Number.isFinite(strikesRaw) && strikesRaw > 0 ? strikesRaw : 0;
               scheduleRender();
             });
+          unsubDailyMessage = db.collection('dailyMessages')
+            .where('isActive', '==', true)
+            .orderBy('createdAt', 'desc')
+            .limit(1)
+            .onSnapshot(snap => {
+              const doc = snap.docs[0];
+              state.dailyMessage = doc ? { id: doc.id, ...doc.data() } : null;
+              scheduleRender();
+            }, err => console.error('Error mensaje diario:', err));
           listenersAttached=true;
         }
 
@@ -695,12 +707,27 @@
               </div>`;
           }).join('') : `<div class="bg-zinc-800 rounded-2xl p-5 text-center text-zinc-400">No hay más clases por ${state.scheduleFilter==='today'?'hoy':'mañana'}.</div>`;
 
+          const activeDailyMessage = state.dailyMessage && state.dailyMessage.message ? state.dailyMessage : null;
+          const dailyMessageHTML = activeDailyMessage ? (()=>{
+            const safeId = DOMPurify.sanitize(activeDailyMessage.id || '');
+            const sanitized = DOMPurify.sanitize(activeDailyMessage.message || '');
+            const formatted = sanitized.replace(/\n/g,'<br>');
+            return `
+              <section aria-live="polite" class="bg-zinc-800 rounded-2xl p-4 flex items-start gap-3" data-message-id="${safeId}">
+                <div class="flex-1 text-sm leading-relaxed text-zinc-100">${formatted}</div>
+                <button type="button" data-action="dismiss-message" class="text-zinc-400 hover:text-zinc-200">
+                  <i data-lucide="x" class="w-5 h-5"></i>
+                </button>
+              </section>`;
+          })() : '';
+
           return `
             <div class="p-6 space-y-8">
               <header>
                 <h1 class="text-3xl font-bold tracking-tight">Tu Agenda</h1>
                 <p class="text-zinc-400">Tus reservas próximas y el horario.</p>
               </header>
+              ${dailyMessageHTML}
               <section aria-labelledby="mis-reservas">
                 <h2 id="mis-reservas" class="text-xl font-semibold mb-3">Tus Reservas</h2>
                 <div class="space-y-3">${reservasHTML}</div>
@@ -1022,6 +1049,10 @@
             case 'cancel-booking': target.disabled=true; app.cancelBooking(classId).finally(()=>target.disabled=false); break;
             case 'join-waitlist': target.disabled=true; app.joinWaitlist(classId).finally(()=>target.disabled=false); break;
             case 'leave-waitlist': target.disabled=true; app.leaveWaitlist(classId).finally(()=>target.disabled=false); break;
+            case 'dismiss-message':
+              state.dailyMessage = null;
+              scheduleRender();
+              break;
 
             /* RESUELTO: usar deep-link + fallback web y confirmación modal
                Mantiene el nombre de acción existente: send-totalpass-daily */


### PR DESCRIPTION
## Summary
- add a Firestore listener and UI section in the PWA agenda screen to surface the latest active daily message
- allow members to dismiss the daily message locally while keeping other listeners intact
- add an admin panel form and realtime list so staff can create, edit, and toggle daily messages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd8f87c7288320933e824dcd8202a9