### PR TITLE
Allow members to read Firestore daily messages

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -111,6 +111,12 @@ service cloud.firestore {
         allow read, write: if isAdmin();
     }
 
+    // ===== DAILY MESSAGES =====
+    match /dailyMessages/{messageId} {
+      allow read: if isSignedIn();
+      allow create, update, delete: if isAdmin();
+    }
+
     // ===== Everything else locked =====
     match /{document=**} {
       allow read, write: if false;


### PR DESCRIPTION
## Summary
- allow authenticated members to read documents in the `dailyMessages` collection without triggering permission errors
- keep daily message creation and updates restricted to admin accounts by gating writes on the `admin` custom claim

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd9310dedc83209548fd9efe2d8a47