### PR TITLE
Fix daily message listener for users

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,11 +258,13 @@
               scheduleRender();
             });
           unsubDailyMessage = db.collection('dailyMessages')
-            .where('isActive', '==', true)
             .orderBy('createdAt', 'desc')
-            .limit(1)
+            .limit(10)
             .onSnapshot(snap => {
-              const doc = snap.docs[0];
+              const doc = snap.docs.find(d => {
+                const data = d.data();
+                return data && data.isActive;
+              });
               state.dailyMessage = doc ? { id: doc.id, ...doc.data() } : null;
               scheduleRender();
             }, err => console.error('Error mensaje diario:', err));


### PR DESCRIPTION
## Summary
- update the client daily message listener to avoid Firestore composite index requirements
- pick the newest active message from the recent snapshot so the banner renders for members

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd94886cf88320918e49793989ba37