### PR TITLE
Add history tab and improve empty reservations CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,10 @@
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="calendar-days" class="lucide lucide-calendar-days w-6 h-6 mb-1"><path d="M8 2v4"></path><path d="M16 2v4"></path><rect width="18" height="18" x="3" y="4" rx="2"></rect><path d="M3 10h18"></path><path d="M8 14h.01"></path><path d="M12 14h.01"></path><path d="M16 14h.01"></path><path d="M8 18h.01"></path><path d="M12 18h.01"></path><path d="M16 18h.01"></path></svg>
             <span class="text-xs font-medium">Agenda</span>
           </button>
+          <button data-screen="history" class="nav-button flex-1 flex flex-col items-center justify-center p-4 text-zinc-400">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="history" class="lucide lucide-history w-6 h-6 mb-1"><path d="M3 3v5h5"></path><path d="M3.05 13A9 9 0 1 0 6 5.3L3 8"></path><path d="M12 7v5l4 2"></path></svg>
+            <span class="text-xs font-medium">Historial</span>
+          </button>
           <button data-screen="profile" class="nav-button flex-1 flex flex-col items-center justify-center p-4 text-zinc-400">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-lucide="user-circle" class="lucide lucide-user-circle w-6 h-6 mb-1"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="10" r="3"></circle><path d="M7 20.662V19a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v1.662"></path></svg>
             <span class="text-xs font-medium">Perfil</span>
@@ -206,7 +210,7 @@
         // Screen via querystring
         const _params = new URLSearchParams(location.search);
         const _screen = _params.get('screen');
-        if (_screen && ['agenda','profile','classDetails'].includes(_screen)) state.currentScreen=_screen;
+        if (_screen && ['agenda','history','profile','classDetails'].includes(_screen)) state.currentScreen=_screen;
 
         // DOM refs
         const mainContent = document.getElementById('main-content');
@@ -524,6 +528,7 @@
           const screen = state.currentScreen;
           let content = '';
           if (screen === 'agenda') content = getAgendaScreenHTML();
+          else if (screen === 'history') content = getHistoryScreenHTML();
           else if (screen === 'profile') content = getProfileScreenHTML();
           else if (screen === 'classDetails') content = getClassDetailsScreenHTML(state.selectedClassId);
           mainContent.innerHTML = `<div class="max-w-md mx-auto">${content}</div>`;
@@ -608,49 +613,11 @@
                 </div>
                 ${showCancelButton ? `<button data-action="cancel-booking" data-class-id="${safeClassId}" class="text-xs text-rose-400 hover:text-rose-300">Cancelar</button>` : ''}
               </div>`;
-          }).join('') : `<div class="bg-zinc-800 rounded-2xl p-5 text-center text-zinc-400">No tienes reservas próximas.</div>`;
-
-          let completadasHTML = '';
-          if (state.isTotalPass) {
-            const today = dateHelper.today;
-            const completed = state.myBookings
-              .filter(Boolean)
-              .map(booking => {
-                const startObj = booking.startAt
-                  ? asDate(booking.startAt)
-                  : (booking.classDate ? new Date(`${booking.classDate}T${booking.time||'00:00'}:00Z`) : null);
-                if (!startObj) return null;
-                const ymdLocal = dateHelper.getYYYYMMDD(startObj);
-                if (ymdLocal !== today) return null;
-                const relatedClass = state.classes.find(cls => cls.id === booking.classId);
-                const durationRaw = Number(booking.duration || relatedClass?.duration || 60);
-                const duration = Number.isFinite(durationRaw) && durationRaw > 0 ? durationRaw : 60;
-                if (Date.now() <= startObj.getTime() + duration * 60000) return null;
-                return { booking, startObj, relatedClass };
-              })
-              .filter(Boolean)
-              .sort((a, b) => b.startObj.getTime() - a.startObj.getTime());
-
-              completadasHTML = completed.length ? completed.map(({ booking, startObj, relatedClass }) => {
-                const className = booking.className || relatedClass?.name || '';
-                const cover = relatedClass ? coverHelper.forClass(relatedClass) : coverHelper.forClassName(className, className);
-                const safeClassName = DOMPurify.sanitize(className);
-                const hhmm = timeFmt.format(startObj);
-                return `
-                  <div class="bg-zinc-800 rounded-2xl p-4 flex items-center gap-4">
-                    <img src="${cover}" alt="${safeClassName}" class="w-16 h-16 rounded-lg object-cover bg-zinc-700" loading="lazy" decoding="async">
-                    <div>
-                      <p class="font-bold text-lg">${safeClassName}</p>
-                      <p class="text-zinc-400 text-sm">Hoy • ${hhmm}</p>
-                    </div>
-                  </div>`;
-              }).join('') : `<div class="bg-zinc-800 rounded-2xl p-5 text-center text-zinc-400">Aún no terminas clases hoy.</div>`;
-
-              const singleTokenButton = completed.length > 0 ?
-                `<button data-action="send-totalpass-daily" class="w-full mt-4 bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-3 rounded-lg">Enviar Token del Día</button>` : '';
-
-              completadasHTML += singleTokenButton;
-          }
+          }).join('') : `
+            <div class="bg-zinc-800 rounded-2xl p-5 text-center space-y-4">
+              <p class="text-zinc-300">Aún no tienes reservas. ¡Anímate a agendar una clase!</p>
+              <button data-action="scroll-to-schedule" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg">Ver Horario</button>
+            </div>`;
 
           const targetYMD = state.scheduleFilter==='today' ? dateHelper.today : dateHelper.tomorrow;
           const filtered = state.classes
@@ -738,11 +705,6 @@
                 <h2 id="mis-reservas" class="text-xl font-semibold mb-3">Tus Reservas</h2>
                 <div class="space-y-3">${reservasHTML}</div>
               </section>
-              ${state.isTotalPass ? `
-              <section aria-labelledby="clases-completadas">
-                <h2 id="clases-completadas" class="text-xl font-semibold mb-3">Clases Terminadas Hoy</h2>
-                <div class="space-y-3">${completadasHTML}</div>
-              </section>` : ''}
               <section aria-labelledby="horario">
                 <div class="flex items-center justify-between mb-3">
                   <h2 id="horario" class="text-xl font-semibold">Horario</h2>
@@ -752,6 +714,91 @@
                   </div>
                 </div>
                 <div class="space-y-3">${horarioHTML}</div>
+              </section>
+            </div>`;
+        }
+
+        function getHistoryScreenHTML(){
+          const now = Date.now();
+          const fourteenDaysMs = 14 * 24 * 60 * 60 * 1000;
+          const completed = state.myBookings
+            .filter(Boolean)
+            .map(booking => {
+              const startObj = booking.startAt
+                ? asDate(booking.startAt)
+                : (booking.classDate ? new Date(`${booking.classDate}T${booking.time||'00:00'}:00Z`) : null);
+              if (!startObj || Number.isNaN(startObj.getTime())) return null;
+              const relatedClass = state.classes.find(cls => cls.id === booking.classId);
+              const durationRaw = booking.duration ?? relatedClass?.duration;
+              const durationValue = Number(durationRaw);
+              const durationMinutes = Number.isFinite(durationValue) && durationValue > 0 ? durationValue : 60;
+              const endTime = startObj.getTime() + durationMinutes * 60000;
+              const ymdLocal = dateHelper.getYYYYMMDD(startObj);
+              return { booking, relatedClass, startObj, endTime, ymdLocal };
+            })
+            .filter(Boolean)
+            .filter(item => now > item.endTime)
+            .sort((a, b) => b.startObj.getTime() - a.startObj.getTime());
+
+          const todayYMD = dateHelper.today;
+          const todays = completed.filter(item => item.ymdLocal === todayYMD);
+          const recent = completed.filter(item => (now - item.startObj.getTime()) <= fourteenDaysMs);
+          const recentPast = recent.filter(item => item.ymdLocal !== todayYMD);
+
+          const renderCard = ({ booking, relatedClass, startObj, ymdLocal }) => {
+            const className = booking.className || relatedClass?.name || '';
+            const cover = relatedClass ? coverHelper.forClass(relatedClass) : coverHelper.forClassName(className, className || 'Clase');
+            const safeClassName = DOMPurify.sanitize(className);
+            const hhmm = timeFmt.format(startObj);
+            const dayLabel = dateHelper.human(ymdLocal);
+            const safeDayLabel = DOMPurify.sanitize(dayLabel);
+            return `
+              <div class="bg-zinc-800 rounded-2xl p-4 flex items-center gap-4">
+                <img src="${cover}" alt="${safeClassName}" class="w-16 h-16 rounded-lg object-cover bg-zinc-700" loading="lazy" decoding="async">
+                <div>
+                  <p class="font-bold text-lg">${safeClassName}</p>
+                  <p class="text-zinc-400 text-sm">${safeDayLabel} • ${hhmm}</p>
+                </div>
+              </div>`;
+          };
+
+          const todayList = todays.length
+            ? todays.map(renderCard).join('')
+            : `<div class="bg-zinc-800 rounded-2xl p-5 text-center text-zinc-400">Aún no terminas clases hoy.</div>`;
+
+          const tokenButton = (state.isTotalPass && todays.length)
+            ? (() => {
+                const firstId = todays[0].booking.classId ? DOMPurify.sanitize(todays[0].booking.classId) : '';
+                const dataAttr = firstId ? ` data-class-id="${firstId}"` : '';
+                return `<button data-action="send-totalpass-daily"${dataAttr} class="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-3 rounded-lg">Enviar Token del Día</button>`;
+              })()
+            : '';
+
+          let historyList = '';
+          if (recentPast.length) {
+            historyList = recentPast.map(renderCard).join('');
+          } else if (todays.length) {
+            historyList = `<div class="bg-zinc-800 rounded-2xl p-5 text-center text-zinc-400">No hay clases anteriores en los últimos 14 días.</div>`;
+          } else {
+            historyList = `<div class="bg-zinc-800 rounded-2xl p-5 text-center text-zinc-400">No hay clases completadas en los últimos 14 días.</div>`;
+          }
+
+          return `
+            <div class="p-6 space-y-8">
+              <header>
+                <h1 class="text-3xl font-bold tracking-tight">Historial</h1>
+                <p class="text-zinc-400">Revisa las clases que ya terminaste.</p>
+              </header>
+              <section aria-labelledby="terminadas-hoy">
+                <h2 id="terminadas-hoy" class="text-xl font-semibold mb-3">Clases Terminadas Hoy</h2>
+                <div class="space-y-3">
+                  ${todayList}
+                  ${tokenButton ? `<div>${tokenButton}</div>` : ''}
+                </div>
+              </section>
+              <section aria-labelledby="historial-reciente">
+                <h2 id="historial-reciente" class="text-xl font-semibold mb-3">Últimos 14 días</h2>
+                <div class="space-y-3">${historyList}</div>
               </section>
             </div>`;
         }
@@ -900,7 +947,8 @@
             }
           },
           navigateTo: (screen, data={})=>{
-            if (screen==='agenda') attachAgendaListeners(); else detachListeners();
+            const needsRealtime = ['agenda','history','classDetails'].includes(screen);
+            if (needsRealtime) attachAgendaListeners(); else detachListeners();
             state.currentScreen = screen;
             if (data.classId) state.selectedClassId = data.classId;
             render();
@@ -1060,6 +1108,11 @@
             case 'navigate': app.navigateTo(screen); break;
             case 'navigate-details': app.navigateTo('classDetails',{classId}); break;
             case 'set-filter': app.setScheduleFilter(filter); break;
+            case 'scroll-to-schedule': {
+              const scheduleHeader = document.getElementById('horario');
+              if (scheduleHeader) scheduleHeader.scrollIntoView({ behavior: 'smooth' });
+              break;
+            }
             case 'edit-name': app.editUserName(e); break;
             case 'logout': app.logout(); break;
             case 'confirm-booking': target.disabled=true; app.confirmBooking(classId).finally(()=>target.disabled=false); break;


### PR DESCRIPTION
## Summary
- add a dedicated Historial tab with completed classes from the last 14 days
- move the Clases Terminadas Hoy section (including TotalPass token button) into the new history screen
- replace the empty reservations message with a friendly CTA that scrolls the user to the schedule

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68ddabb57b38832097e257ee5acb4201