### PR TITLE
Simplify class capacity label

### DIFF
--- a/index.html
+++ b/index.html
@@ -881,7 +881,7 @@
           const safeId = DOMPurify.sanitize(cls.id);
           const capacityValue = Number(cls.capacity||0);
           const availableLabel = capacityValue>0
-            ? `${Math.max(capacityValue - enrolled, 0)} disponibles • ${enrolled}/${capacityValue} ocupados`
+            ? `${enrolled}/${capacityValue} ocupados`
             : 'Capacidad no definida';
           const durationLabel = (()=>{
             if (!Number.isFinite(durationMin) || durationMin<=0) return 'Duración no definida';


### PR DESCRIPTION
## Summary
- replace the class availability label with a concise occupied count format

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddba5f31cc83208279b06172854c0e