### PR TITLE
Improve cancel button tap target in reservations

### DIFF
--- a/index.html
+++ b/index.html
@@ -621,7 +621,7 @@
                     <p class="${countdownClass} text-xs mt-0.5">${safeTimeStatus}</p>
                   </div>
                 </div>
-                ${showCancelButton ? `<button data-action="cancel-booking" data-class-id="${safeClassId}" class="text-xs text-rose-400 hover:text-rose-300">Cancelar</button>` : ''}
+                ${showCancelButton ? `<button type="button" data-action="cancel-booking" data-class-id="${safeClassId}" class="inline-flex items-center justify-center px-3 py-1.5 text-sm font-semibold text-rose-400 border border-rose-400 rounded-lg hover:bg-rose-500/10 focus:outline-none focus:ring-2 focus:ring-rose-500/40">Cancelar</button>` : ''}
               </div>`;
           }).join('') : `
             <div class="bg-zinc-800 rounded-2xl p-5 text-center space-y-4">


### PR DESCRIPTION
## Summary
- restyle the "Cancelar" action in the reservations list as a red ghost button to emphasize its destructive role
- enlarge the button's tap target and add focus states for better mobile usability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddd368c8608320b4b0617b674cdfe1