### PR TITLE
Adjust booking back button overlay styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -945,7 +945,7 @@
             <div>
               <div class="relative">
                 <img src="${coverHelper.forClass(cls)}" class="w-full h-64 object-cover" alt="${safeName}">
-                <button data-action="navigate" data-screen="agenda" class="absolute top-6 left-6 bg-black/50 p-2 rounded-full text-white">
+                <button data-action="navigate" data-screen="agenda" class="absolute top-6 left-6 z-10 bg-black/50 backdrop-blur p-2 rounded-full text-white shadow-lg">
                   <i data-lucide="arrow-left" class="w-6 h-6"></i>
                 </button>
               </div>


### PR DESCRIPTION
## Summary
- ensure the agenda back button stays visible over the class cover image by increasing its stacking order
- add a subtle blur and shadow so the floating control is easier to see on top of photos

## Testing
- not run (visual change only)


------
https://chatgpt.com/codex/tasks/task_e_68de9feafd148320aa97dfcfdc572756