### PR TITLE
Ensure class details back button stays fixed over cover image

### DIFF
--- a/index.html
+++ b/index.html
@@ -943,9 +943,9 @@
           }
           return `
             <div>
-              <div class="relative">
+              <div class="relative sticky top-0 z-20">
                 <img src="${coverHelper.forClass(cls)}" class="w-full h-64 object-cover" alt="${safeName}">
-                <button data-action="navigate" data-screen="agenda" class="absolute top-6 left-6 z-10 bg-black/50 backdrop-blur p-2 rounded-full text-white shadow-lg">
+                <button data-action="navigate" data-screen="agenda" class="absolute top-6 left-6 z-30 bg-black/50 backdrop-blur p-2 rounded-full text-white shadow-lg">
                   <i data-lucide="arrow-left" class="w-6 h-6"></i>
                 </button>
               </div>


### PR DESCRIPTION
## Summary
- keep the class details hero section sticky so the cover image and back button stay in view while scrolling
- raise the back button z-index to ensure it remains visible over the cover image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deae594d108320a42150d5c487bdbc