### PR TITLE
Fix waitlist position assignment in joinWaitlist

### DIFF
--- a/index.html
+++ b/index.html
@@ -1163,8 +1163,21 @@
           joinWaitlist: async (classId)=>{
             const uid = state.currentUser.uid;
             try{
+              // Revisamos la lista para conocer la siguiente posición disponible.
+              const existingEntries = await db.collection('waitlists')
+                .where('classId','==',classId)
+                .get();
+
+              let nextPosition = 1;
+              if (!existingEntries.empty){
+                const positions = existingEntries.docs.map(doc=>Number(doc.data()?.position) || 0);
+                nextPosition = Math.max(...positions) + 1;
+              }
+
               await db.collection('waitlists').doc(`${classId}_${uid}`).set({
-                classId, userId: uid,
+                classId,
+                userId: uid,
+                position: nextPosition,
                 createdAt: firebase.firestore.FieldValue.serverTimestamp()
               });
               showToast('Unido a la lista de espera', 'success');


### PR DESCRIPTION
## Summary
- ensure waitlist entries are assigned sequential positions when users join a waitlist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0145e17a48320b058917bcea20490