### PR TITLE
Fix waitlist position shifting when users leave

### DIFF
--- a/index.html
+++ b/index.html
@@ -1186,9 +1186,33 @@
           leaveWaitlist: async (classId)=>{
             const uid = state.currentUser.uid;
             try{
-              await db.collection('waitlists').doc(`${classId}_${uid}`).delete();
+              const waitRef = db.collection('waitlists').doc(`${classId}_${uid}`);
+              const waitSnap = await waitRef.get();
+
+              if (!waitSnap.exists) {
+                showToast('No estás en la lista de espera');
+                return;
+              }
+
+              const userPosition = waitSnap.data().position || 1;
+
+              await waitRef.delete();
+
+              const q = await db.collection('waitlists')
+                .where('classId', '==', classId)
+                .where('position', '>', userPosition)
+                .get();
+
+              const batch = db.batch();
+              q.forEach(doc => {
+                batch.update(doc.ref, { position: (doc.data().position || 1) - 1 });
+              });
+              await batch.commit();
+
               showToast('Saliste de la lista de espera');
-            }catch(err){ alert(`No se pudo salir de la lista de espera\n\n${err.message}`); }
+            }catch(err){
+              alert(`No se pudo salir de la lista de espera\n\n${err.message}`);
+            }
           }
         };
 


### PR DESCRIPTION
## Summary
- add missing waitlist position shifting logic to the manual leave flow
- keep users informed when they are not in the waitlist anymore

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e018baf5988320bd2c39a7d67173c1