### PR TITLE
Ensure waitlist entries include position values

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -5,6 +5,14 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "classId", "order": "ASCENDING" },
+        { "fieldPath": "position", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "waitlists",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "classId", "order": "ASCENDING" },
         { "fieldPath": "position", "order": "ASCENDING" }
       ]
     },

--- a/index.html
+++ b/index.html
@@ -1163,8 +1163,18 @@
           joinWaitlist: async (classId)=>{
             const uid = state.currentUser.uid;
             try{
+              const snap = await db.collection('waitlists')
+                .where('classId', '==', classId)
+                .orderBy('position', 'desc')
+                .limit(1)
+                .get();
+
+              const maxPosition = snap.empty ? 0 : (snap.docs[0].data().position || 0);
+
               await db.collection('waitlists').doc(`${classId}_${uid}`).set({
-                classId, userId: uid,
+                classId,
+                userId: uid,
+                position: maxPosition + 1,
                 createdAt: firebase.firestore.FieldValue.serverTimestamp()
               });
               showToast('Unido a la lista de espera', 'success');


### PR DESCRIPTION
## Summary
- update the waitlist join logic to assign sequential position values so FIFO ordering works
- add the Firestore composite index for classId ascending and position descending to support the new query

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e22f4741d883208aa23f13bce80a5d