### PR TITLE
Update favicons for user and admin pages

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -14,6 +14,9 @@
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/png" sizes="192x192" href="./images/admin-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="./images/admin-512x512.png">
+    <link rel="apple-touch-icon" href="./images/admin-192x192.png">
     <style>
       body { font-family: 'Inter', sans-serif; }
       :focus-visible { outline: 2px solid #818cf8; outline-offset: 2px; border-radius: .5rem; }

--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
     <!-- PWA -->
     <link rel="manifest" href="./manifest.json">
     <meta name="theme-color" content="#18181b">
+    <link rel="icon" type="image/png" sizes="192x192" href="./images/icon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="./images/icon-512x512.png">
 
     <!-- iOS -->
     <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## Summary
- add dedicated favicon links for the main user PWA using the 192x192 and 512x512 icons
- configure the admin panel to reference its own favicon and PWA icons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5d94e75108320b678125688f13eb7