### PR TITLE
Enable admin panel installation as standalone PWA

### DIFF
--- a/admin-manifest.json
+++ b/admin-manifest.json
@@ -1,0 +1,30 @@
+{
+  "name": "Madness Admin - Panel de Control",
+  "short_name": "Madness Admin",
+  "description": "Gestiona clases, reservas y asistentes desde el panel administrativo de Madness.",
+  "start_url": "./admin.html?source=pwa",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#18181b",
+  "theme_color": "#18181b",
+  "orientation": "portrait",
+  "icons": [
+    { "src": "./images/admin-192x192.png", "type": "image/png", "sizes": "192x192" },
+    { "src": "./images/admin-512x512.png", "type": "image/png", "sizes": "512x512" },
+    { "src": "./images/admin-512x512.png", "type": "image/png", "sizes": "512x512", "purpose": "maskable any" }
+  ],
+  "shortcuts": [
+    {
+      "name": "Calendario de Clases",
+      "short_name": "Calendario",
+      "url": "./admin.html#calendar",
+      "icons": [{ "src": "./images/admin-192x192.png", "sizes": "192x192", "type": "image/png" }]
+    },
+    {
+      "name": "Panel de Waitlist",
+      "short_name": "Waitlist",
+      "url": "./admin.html#waitlist",
+      "icons": [{ "src": "./images/admin-192x192.png", "sizes": "192x192", "type": "image/png" }]
+    }
+  ]
+}

--- a/admin.html
+++ b/admin.html
@@ -8,12 +8,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no" />
     <title>Madness - Panel de Administrador</title>
+    <meta name="theme-color" content="#18181b" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="manifest" href="./admin-manifest.json" />
     <link rel="icon" type="image/png" sizes="192x192" href="./images/admin-192x192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="./images/admin-512x512.png">
     <link rel="apple-touch-icon" href="./images/admin-192x192.png">
@@ -3796,6 +3798,16 @@
       };
 
       AdminPanel.init();
+
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', async () => {
+          try {
+            await navigator.serviceWorker.register('/service-worker.js', { scope: '/' });
+          }catch(error){
+            console.error('No se pudo registrar el Service Worker para el panel admin:', error);
+          }
+        });
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add an admin-specific web manifest so the panel installs with the right entry point and icons
- expose the manifest plus theme color metadata from admin.html
- register the shared service worker when the admin panel loads so installability checks pass

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5d9be62b88320b17247c21958dd80