### PR TITLE
Upgrade Firebase Functions runtime to Node.js 22 - v2

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Upgrades Firebase Cloud Functions runtime from Node.js 20 to Node.js 22 before the April 30, 2026 deprecation deadline.