### PR TITLE
fix: reduce tab navigation firestore reads

### DIFF
--- a/index.html
+++ b/index.html
@@ -1425,8 +1425,9 @@
             }
           },
           navigateTo: (screen, data={})=>{
-            const needsRealtime = ['agenda','history','classDetails'].includes(screen);
-            if (needsRealtime) attachAgendaListeners(); else detachListeners();
+            // Keep listeners alive while logged in so tab changes reuse cached state.
+            // Detaching on Perfil and re-attaching on Agenda can cause extra Firestore reads.
+            attachAgendaListeners();
             state.currentScreen = screen;
             if (data.classId) state.selectedClassId = data.classId;
             render();

--- a/index.html
+++ b/index.html
@@ -378,7 +378,7 @@
           }
           dailyMessageRotation.index = 0;
           state.dailyMessage = dailyMessageRotation.messages[0];
-          scheduleRender();
+          scheduleAgendaDataRender();
           dailyMessageRotation.intervalId = setInterval(()=>{
             if (!dailyMessageRotation.messages.length){
               stopDailyMessageRotation();
@@ -386,7 +386,7 @@
             }
             dailyMessageRotation.index = (dailyMessageRotation.index + 1) % dailyMessageRotation.messages.length;
             state.dailyMessage = dailyMessageRotation.messages[dailyMessageRotation.index];
-            scheduleRender();
+            scheduleAgendaDataRender();
           }, DAILY_MESSAGE_ROTATION_MS);
         }
 
@@ -409,6 +409,10 @@
           if (renderQueued) return;
           renderQueued=true;
           requestAnimationFrame(()=>{ renderQueued=false; render(); });
+        }
+        function scheduleAgendaDataRender(){
+          // Agenda data can update in the background, but Perfil should not rebuild for it.
+          if (['agenda','history','classDetails'].includes(state.currentScreen)) scheduleRender();
         }
 
         // Screen via querystring
@@ -467,33 +471,33 @@
           if (listenersAttached || !state.currentUser) return;
           state.loading.classes = true;
           state.loading.bookings = true;
-          scheduleRender();
+          scheduleAgendaDataRender();
           const nowMinus5 = new Date(Date.now()-5*60*1000);
           unsubClasses = db.collection('classes').where('startAt','>=',nowMinus5).orderBy('startAt','asc').limit(100)
             .onSnapshot(snap=>{
               state.classes = snap.docs.map(d=>({id:d.id,...d.data()}));
               state.loading.classes = false;
-              scheduleRender();
+              scheduleAgendaDataRender();
             }, err=>{
               console.error('Error clases:', err);
               state.loading.classes = false;
-              scheduleRender();
+              scheduleAgendaDataRender();
             });
           unsubMyBookings = db.collection('bookings').where('userId','==',state.currentUser.uid)
             .onSnapshot(snap=>{
               state.myBookings = snap.docs.map(d=>({id:d.id,...d.data()}));
               state.loading.bookings = false;
-              scheduleRender();
+              scheduleAgendaDataRender();
             }, err=>{
               console.error('Error mis reservas:', err);
               state.loading.bookings = false;
-              scheduleRender();
+              scheduleAgendaDataRender();
             });
           unsubWaitlist = db.collection('waitlists')
             .where('userId', '==', state.currentUser.uid)
             .onSnapshot(snap => {
               state.waitlistEntries = snap.docs.map(d=>({id:d.id,...d.data()}));
-              scheduleRender();
+              scheduleAgendaDataRender();
             });
           unsubAttendance = db.collection('attendance')
             .where('userId', '==', state.currentUser.uid)
@@ -506,7 +510,7 @@
                 records[data.classId] = { status: rawStatus };
               });
               state.attendanceRecords = records;
-              scheduleRender();
+              scheduleAgendaDataRender();
             }, err => {
               console.error('Error asistencia usuario:', err);
             });
@@ -546,13 +550,13 @@
               if (!activeMessages.length){
                 stopDailyMessageRotation();
                 state.dailyMessage = null;
-                scheduleRender();
+                scheduleAgendaDataRender();
                 return;
               }
               if (activeMessages.length === 1){
                 stopDailyMessageRotation();
                 state.dailyMessage = activeMessages[0];
-                scheduleRender();
+                scheduleAgendaDataRender();
                 return;
               }
               startDailyMessageRotation(activeMessages);
@@ -561,7 +565,7 @@
               stopDailyMessageRotation();
               state.dailyMessageList = [];
               state.dailyMessage = null;
-              scheduleRender();
+              scheduleAgendaDataRender();
             });
           listenersAttached=true;
         }
@@ -1425,11 +1429,11 @@
             }
           },
           navigateTo: (screen, data={})=>{
-            // Keep listeners alive while logged in so tab changes reuse cached state.
-            // Detaching on Perfil and re-attaching on Agenda can cause extra Firestore reads.
-            attachAgendaListeners();
             state.currentScreen = screen;
             if (data.classId) state.selectedClassId = data.classId;
+            // Keep listeners alive while logged in so tab changes reuse cached state.
+            // Perfil should not start agenda reads, but it also should not detach them.
+            if (['agenda','history','classDetails'].includes(screen)) attachAgendaListeners();
             render();
           },
           setScheduleFilter: (filter)=>{ state.scheduleFilter=filter; render(); },


### PR DESCRIPTION
**Motivation:**
Tab navigation was detaching Firebase listeners when users opened Perfil, then re-attaching them when they returned to Agenda or Historial. That can trigger avoidable Firestore reads and makes cached client state less useful.

**Proposed Changes:**
- Keep agenda-related Firestore listeners alive while the user is logged in.
- Reuse existing cached state when switching between Agenda, Historial, and Perfil.
- Leave listener cleanup on logout through the existing detach flow.

**Testing:**
```powershell
node -e "const fs=require('fs'); const html=fs.readFileSync('index.html','utf8'); const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)].map(m=>m[1]); scripts.forEach((code,i)=>new Function(code)); console.log('inline scripts parsed:', scripts.length);"

git diff --check

npm test
```
