### PR TITLE
fix: refresh PWA agenda on resume

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,7 +445,11 @@
         window.showToast = showToast;
 
         // Firestore listeners
+        const AGENDA_REFRESH_MIN_MS = 60000;
+        const AGENDA_SCREENS = ['agenda', 'history', 'classDetails'];
         let unsubClasses=null, unsubMyBookings=null, unsubWaitlist=null, unsubUser=null, unsubDailyMessage=null, unsubAttendance=null, listenersAttached=false;
+        let lastAgendaResumeRefreshAt = 0;
+        let resumeRefreshHandlersAttached = false;
         function detachListeners(){
           if (unsubClasses){ try{unsubClasses();}catch{}; unsubClasses=null; }
           if (unsubMyBookings){ try{unsubMyBookings();}catch{}; unsubMyBookings=null; }
@@ -466,6 +470,16 @@
           }
           scheduleRender();
           listenersAttached=false;
+        }
+        function refreshAgendaListenersOnResume(){
+          if (!state.currentUser || !AGENDA_SCREENS.includes(state.currentScreen)) return;
+
+          const now = Date.now();
+          if (now - lastAgendaResumeRefreshAt < AGENDA_REFRESH_MIN_MS) return;
+          lastAgendaResumeRefreshAt = now;
+
+          if (listenersAttached) detachListeners();
+          attachAgendaListeners();
         }
         function attachAgendaListeners(){
           if (listenersAttached || !state.currentUser) return;
@@ -737,8 +751,19 @@
                 try { await ensureFreshFcmToken(auth.currentUser.uid); } catch {}
               }
             }, { once:true });
+            if (!resumeRefreshHandlersAttached) {
+              document.addEventListener('visibilitychange', () => {
+                if (document.visibilityState === 'visible') refreshAgendaListenersOnResume();
+              });
+              window.addEventListener('pageshow', refreshAgendaListenersOnResume);
+              window.addEventListener('focus', refreshAgendaListenersOnResume);
+              resumeRefreshHandlersAttached = true;
+            }
 
-            if (state.currentScreen === 'agenda') attachAgendaListeners();
+            if (state.currentScreen === 'agenda') {
+              lastAgendaResumeRefreshAt = Date.now();
+              attachAgendaListeners();
+            }
             scheduleRender();
           } else {
             state.currentUser = null;

--- a/index.html
+++ b/index.html
@@ -449,6 +449,7 @@
         const AGENDA_SCREENS = ['agenda', 'history', 'classDetails'];
         let unsubClasses=null, unsubMyBookings=null, unsubWaitlist=null, unsubUser=null, unsubDailyMessage=null, unsubAttendance=null, listenersAttached=false;
         let lastAgendaResumeRefreshAt = 0;
+        let pendingAgendaResumeRefresh = false;
         let resumeRefreshHandlersAttached = false;
         function detachListeners(){
           if (unsubClasses){ try{unsubClasses();}catch{}; unsubClasses=null; }
@@ -470,13 +471,21 @@
           }
           scheduleRender();
           listenersAttached=false;
+          pendingAgendaResumeRefresh=false;
         }
-        function refreshAgendaListenersOnResume(){
-          if (!state.currentUser || !AGENDA_SCREENS.includes(state.currentScreen)) return;
+        function refreshAgendaListenersOnResume(force=false){
+          if (!state.currentUser) return;
+
+          const isAgendaScreen = AGENDA_SCREENS.includes(state.currentScreen);
+          if (!isAgendaScreen) {
+            pendingAgendaResumeRefresh = listenersAttached;
+            return;
+          }
 
           const now = Date.now();
-          if (now - lastAgendaResumeRefreshAt < AGENDA_REFRESH_MIN_MS) return;
+          if (!force && now - lastAgendaResumeRefreshAt < AGENDA_REFRESH_MIN_MS) return;
           lastAgendaResumeRefreshAt = now;
+          pendingAgendaResumeRefresh = false;
 
           if (listenersAttached) detachListeners();
           attachAgendaListeners();
@@ -1458,7 +1467,13 @@
             if (data.classId) state.selectedClassId = data.classId;
             // Keep listeners alive while logged in so tab changes reuse cached state.
             // Perfil should not start agenda reads, but it also should not detach them.
-            if (['agenda','history','classDetails'].includes(screen)) attachAgendaListeners();
+            if (AGENDA_SCREENS.includes(screen)) {
+              if (pendingAgendaResumeRefresh) {
+                refreshAgendaListenersOnResume(true);
+              } else {
+                attachAgendaListeners();
+              }
+            }
             render();
           },
           setScheduleFilter: (filter)=>{ state.scheduleFilter=filter; render(); },


### PR DESCRIPTION
**Motivation:**
The user PWA could show stale Agenda classes after being resumed from the background. This happened because the app kept the existing Firebase listeners alive for tab switching, but did not force Agenda data to refresh when the installed PWA became active again.

**Proposed Changes:**
- Add a small throttled resume refresh for Agenda-related screens.
- Reattach Agenda listeners on `visibilitychange`, `pageshow`, or `focus` when the app is visible again.
- Keep normal Agenda / Historial / Perfil navigation from detaching and reattaching listeners.
- Limit resume refreshes to once per minute so it does not create repeated reads every few seconds.

**Testing:**
```powershell
node -e "const fs=require('fs');const vm=require('vm');const html=fs.readFileSync('index.html','utf8');const scripts=[...html.matchAll(/<script(?![^>]*src=)[^>]*>([\s\S]*?)<\/script>/gi)].map(m=>m[1]);scripts.forEach((code,i)=>new vm.Script(code,{filename:'index.html inline script '+(i+1)}));console.log('Parsed '+scripts.length+' inline scripts');"

git diff --check

npm test
```

`npm test` currently reports `No tests specified` and exits successfully.